### PR TITLE
Avoid draining large request bodies during LLM approval

### DIFF
--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -31,11 +31,16 @@ const ContextKeyOriginalHeaders contextKey = "original_headers"
 // ContextKeyOriginalBody carries the request body for the LLM judge evaluation.
 const ContextKeyOriginalBody contextKey = "original_body"
 
+// ContextKeyBufferedBody carries the raw request body bytes already buffered by
+// the proxy. When present, CheckApproval must not read req.Body again because
+// large uploads may still have an unread streaming tail attached to req.Body.
+const ContextKeyBufferedBody contextKey = "buffered_body"
+
 // Manager orchestrates the approval decision flow
 type Manager struct {
 	judge        *judge.LLMJudge // nil if LLM mode disabled
-	mode         string      // "llm" | "passthrough"
-	fallbackMode string      // "deny" | "passthrough"
+	mode         string          // "llm" | "passthrough"
+	fallbackMode string          // "deny" | "passthrough"
 
 }
 
@@ -86,17 +91,10 @@ func (m *Manager) CheckApproval(ctx context.Context, req *http.Request, requestI
 
 // checkApprovalLLM evaluates the request with the LLM judge.
 func (m *Manager) checkApprovalLLM(ctx context.Context, req *http.Request, requestID string, apiInfo *types.APIInfo) (types.ApprovalDecision, []byte, error) {
-	// Read request body so it can be forwarded after inspection.
-	var body []byte
-	if req.Body != nil {
-		var err error
-		body, err = io.ReadAll(req.Body)
-		if err != nil {
-			return types.ApprovalDecision{}, nil, fmt.Errorf("failed to read request body: %w", err)
-		}
-		req.Body.Close()
+	body, err := requestBodyForApproval(ctx, req)
+	if err != nil {
+		return types.ApprovalDecision{}, nil, err
 	}
-	req.Body = io.NopCloser(bytes.NewReader(body))
 
 	// Retrieve LLM policy from context (set by the proxy handler per-user).
 	policy, _ := ctx.Value(ContextKeyLLMPolicy).(*types.LLMPolicy)
@@ -186,6 +184,28 @@ func (m *Manager) checkApprovalLLM(ctx context.Context, req *http.Request, reque
 		ad.LLMResponse = llmResp
 		return ad, b, err
 	}
+}
+
+// requestBodyForApproval returns request bytes for policy checks and for callers
+// that need to replay the request upstream. If the proxy already buffered the
+// request prefix, use that copy and leave req.Body untouched so large uploads
+// can continue streaming after approval.
+func requestBodyForApproval(ctx context.Context, req *http.Request) ([]byte, error) {
+	if body, ok := ctx.Value(ContextKeyBufferedBody).([]byte); ok {
+		return body, nil
+	}
+
+	var body []byte
+	if req.Body != nil {
+		var err error
+		body, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read request body: %w", err)
+		}
+		req.Body.Close()
+	}
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	return body, nil
 }
 
 // llmFallback handles the case where the LLM judge is unavailable or returns no valid decision.

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -77,7 +77,7 @@ func init() {
 // extractEmbeddedIPv4. They correspond to the NAT64 and 6to4 CIDR ranges
 // added to blockedNetworks above.
 var (
-	nat64Prefix    *net.IPNet
+	nat64Prefix     *net.IPNet
 	sixtofourPrefix *net.IPNet
 )
 
@@ -219,13 +219,13 @@ type LLMResponseWriter interface {
 
 // Handler handles HTTP/HTTPS proxy requests
 type Handler struct {
-	tlsManager          *TLSManager
-	approvalManager     *approval.Manager
-	auditLogger         *audit.Logger
-	auditReader         admin.AuditReaderIface
-	userResolver        admin.UserResolver
-	llmResponseWriter   LLMResponseWriter // nil if llm_responses persistence disabled
-	client              *http.Client
+	tlsManager        *TLSManager
+	approvalManager   *approval.Manager
+	auditLogger       *audit.Logger
+	auditReader       admin.AuditReaderIface
+	userResolver      admin.UserResolver
+	llmResponseWriter LLMResponseWriter // nil if llm_responses persistence disabled
+	client            *http.Client
 
 	// allowedPrivateCIDRs lists CIDR ranges exempted from the default SSRF
 	// blocklist. IPs falling within these ranges will not be blocked even if
@@ -789,7 +789,7 @@ func (h *Handler) handleHTTPWebSocket(w http.ResponseWriter, r *http.Request, re
 type approvalResult struct {
 	decision      types.ApprovalDecision
 	userID        string
-	llmResponseID string         // persisted llm_responses row ID (if judge ran)
+	llmResponseID string // persisted llm_responses row ID (if judge ran)
 	approved      bool
 	denyResp      *http.Response // non-nil when approved==false
 }
@@ -895,6 +895,7 @@ func (h *Handler) processUpgradeApproval(r *http.Request, requestID string, star
 		}
 		// If decompression failed, keep original body + Content-Encoding header.
 	}
+	ctx = context.WithValue(ctx, approval.ContextKeyBufferedBody, requestBody)
 	ctx = context.WithValue(ctx, approval.ContextKeyOriginalHeaders, wsEvalHeaders)
 	ctx = context.WithValue(ctx, approval.ContextKeyOriginalBody, wsEvalBody)
 	decision, _, approvalErr := h.approvalManager.CheckApproval(ctx, r, requestID, nil)
@@ -1347,6 +1348,7 @@ func (h *Handler) processRequest(r *http.Request, requestID string, startTime ti
 		// keep the original body AND the Content-Encoding header so the LLM
 		// knows it is looking at encoded content it could not decode.
 	}
+	ctx = context.WithValue(ctx, approval.ContextKeyBufferedBody, originalRequestBody)
 	ctx = context.WithValue(ctx, approval.ContextKeyOriginalHeaders, evalHeaders)
 	ctx = context.WithValue(ctx, approval.ContextKeyOriginalBody, evalBody)
 	decision, body, approvalErr = h.approvalManager.CheckApproval(ctx, r, requestID, nil)
@@ -1615,11 +1617,11 @@ func newEntry(requestID string, r *http.Request, requestHeaders http.Header, sta
 // applyDecision copies the approval decision fields onto an entry.
 // Used on paths where the LLM judge ran.
 func applyDecision(e *types.AuditEntry, d types.ApprovalDecision, llmResponseID, llmReason string) {
-	e.ApprovedBy    = d.ApprovedBy
-	e.Channel       = d.Channel
-	e.LLMPolicyID   = d.LLMPolicyID
+	e.ApprovedBy = d.ApprovedBy
+	e.Channel = d.Channel
+	e.LLMPolicyID = d.LLMPolicyID
 	e.LLMResponseID = llmResponseID
-	e.LLMReason     = llmReason // for SSE broadcast; not stored in DB column
+	e.LLMReason = llmReason // for SSE broadcast; not stored in DB column
 }
 
 // logEntry dispatches a fully-built audit entry to the DB reader, SSE, and audit file.
@@ -1893,4 +1895,3 @@ func (h *Handler) formatBody(body []byte, requestID string) string {
 	}
 	return bodyStr
 }
-

--- a/internal/proxy/streaming_test.go
+++ b/internal/proxy/streaming_test.go
@@ -8,10 +8,16 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/brexhq/CrabTrap/internal/approval"
 	"github.com/brexhq/CrabTrap/internal/audit"
+	"github.com/brexhq/CrabTrap/internal/judge"
+	"github.com/brexhq/CrabTrap/internal/llm"
+	"github.com/brexhq/CrabTrap/pkg/types"
 )
 
 const largeBodySize = maxBufferedBodySize + 1024*1024 // 11 MB — exceeds the 10 MB cap
@@ -217,5 +223,141 @@ func TestLargeUploadReachesUpstream(t *testing.T) {
 	// processRequest returns the value is already populated.
 	if receivedSize != largeBodySize {
 		t.Errorf("upstream received %d bytes, want %d", receivedSize, largeBodySize)
+	}
+}
+
+type gatedTailReader struct {
+	data                 []byte
+	release              <-chan struct{}
+	upstreamStarted      *atomic.Bool
+	readBeforeUpstreamCh chan<- struct{}
+	pos                  int
+}
+
+func (r *gatedTailReader) Read(p []byte) (int, error) {
+	if !r.upstreamStarted.Load() {
+		select {
+		case r.readBeforeUpstreamCh <- struct{}{}:
+		default:
+		}
+	}
+	<-r.release
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+// TestLargeUploadLLMStaticRuleDoesNotDrainStreamingTail verifies that LLM-mode
+// approval uses the proxy's buffered request prefix instead of reading the full
+// streaming body before forwarding. Static rules are checked before the judge,
+// so approval should complete without consuming the unread tail of a large body.
+func TestLargeUploadLLMStaticRuleDoesNotDrainStreamingTail(t *testing.T) {
+	prefix := makeLargeBody(maxBufferedBodySize + 1)
+	tailData := []byte("tail-after-buffer-limit")
+	releaseTail := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(releaseTail) })
+
+	var upstreamStarted atomic.Bool
+	readBeforeUpstream := make(chan struct{}, 1)
+	tail := &gatedTailReader{
+		data:                 tailData,
+		release:              releaseTail,
+		upstreamStarted:      &upstreamStarted,
+		readBeforeUpstreamCh: readBeforeUpstream,
+	}
+
+	upstreamReached := make(chan struct{})
+	upstreamReceived := make(chan int64, 1)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamStarted.Store(true)
+		close(upstreamReached)
+		n, err := io.Copy(io.Discard, r.Body)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("body read error: %v", err), http.StatusInternalServerError)
+			return
+		}
+		upstreamReceived <- n
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer backend.Close()
+
+	adapterCalled := make(chan struct{}, 1)
+	mgr := approval.NewManager()
+	mgr.SetJudge(judge.NewLLMJudge(&llm.TestAdapter{Fn: func(req llm.Request) (llm.Response, error) {
+		select {
+		case adapterCalled <- struct{}{}:
+		default:
+		}
+		return llm.Response{Text: `{"decision":"ALLOW","reason":"fallback"}`}, nil
+	}}), "llm", "deny")
+
+	auditLogger, err := audit.NewLogger(filepath.Join(t.TempDir(), "audit.jsonl"))
+	if err != nil {
+		t.Fatalf("audit logger: %v", err)
+	}
+	defer auditLogger.Close()
+
+	handler := NewHandler(nil, mgr, auditLogger, nil, nil, true)
+	handler.allowedPrivateCIDRs = testLoopbackCIDRs()
+	handler.initClient()
+
+	policy := &types.LLMPolicy{
+		ID:     "llmpol_large_upload_static",
+		Name:   "large upload static allow",
+		Prompt: "deny everything unless a static rule allows it",
+		StaticRules: []types.StaticRule{{
+			Methods:    []string{http.MethodPost},
+			URLPattern: backend.URL + "/",
+			MatchType:  "prefix",
+			Action:     "allow",
+		}},
+	}
+	ctx := context.WithValue(context.Background(), approval.ContextKeyLLMPolicy, policy)
+
+	body := io.NopCloser(io.MultiReader(bytes.NewReader(prefix), tail))
+	req, err := http.NewRequest(http.MethodPost, backend.URL+"/upload", body)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.ContentLength = int64(len(prefix) + len(tailData))
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	respCh := make(chan *http.Response, 1)
+	go func() {
+		respCh <- handler.processRequest(req, "req_large_llm_static", time.Now(), ctx)
+	}()
+
+	select {
+	case <-upstreamReached:
+		// Good: approval completed and forwarding began without draining tail.
+	case <-readBeforeUpstream:
+		releaseOnce.Do(func() { close(releaseTail) })
+		t.Fatal("approval read the streaming tail before the request reached upstream")
+	case <-time.After(2 * time.Second):
+		releaseOnce.Do(func() { close(releaseTail) })
+		t.Fatal("request did not reach upstream; approval may be blocked reading the body")
+	}
+
+	releaseOnce.Do(func() { close(releaseTail) })
+
+	resp := <-respCh
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", resp.StatusCode)
+	}
+
+	if got := <-upstreamReceived; got != int64(len(prefix)+len(tailData)) {
+		t.Fatalf("upstream received %d bytes, want %d", got, len(prefix)+len(tailData))
+	}
+
+	select {
+	case <-adapterCalled:
+		t.Fatal("static allow rule should bypass the LLM judge")
+	default:
 	}
 }


### PR DESCRIPTION
## Summary
- Add an approval context value for the raw body bytes already buffered by the proxy.
- Use that buffered copy in LLM approval instead of reading `req.Body` again, preserving the unread streaming tail for upstream forwarding.
- Add a regression test that fails if LLM-mode static-rule approval consumes the tail of a large upload before the request reaches upstream.

Fixes #2

## Testing
- `go test ./internal/judge ./internal/llm ./internal/config ./internal/builder ./internal/envutil`
- `go test ./internal/proxy -run TestLargeUploadLLMStaticRuleDoesNotDrainStreamingTail -count=1` (blocked locally: package TestMain starts testcontainers and Docker is unavailable, `rootless Docker not found`)
- `env PATH=/Users/nathanmetzger/go/bin:$PATH make test` (go vet/staticcheck completed; `go test -race -p 1 ./...` is blocked locally by the same missing Docker/testcontainers environment)