### PR TITLE
Stream response bodies while sampling audit data

### DIFF
--- a/internal/admin/api_auth_test.go
+++ b/internal/admin/api_auth_test.go
@@ -31,13 +31,18 @@ func (v *stubValidator) GetUserByWebToken(token string) (string, bool, bool) {
 
 type stubAuditReader struct{}
 
-func (r *stubAuditReader) Add(_ types.AuditEntry)                             {}
-func (r *stubAuditReader) Query(_ AuditFilter) []types.AuditEntry             { return nil }
+func (r *stubAuditReader) Add(_ types.AuditEntry)                 {}
+func (r *stubAuditReader) Query(_ AuditFilter) []types.AuditEntry { return nil }
 func (r *stubAuditReader) QueryBatched(_ context.Context, _ AuditFilter, _ int, _ func([]types.AuditEntry) error) error {
 	return nil
 }
 func (r *stubAuditReader) Count(_ context.Context, _ AuditFilter) (int, error) { return 0, nil }
-func (r *stubAuditReader) GetEntry(_ string) (*types.AuditEntry, error)        { return nil, fmt.Errorf("not found") }
+func (r *stubAuditReader) UpdateResponse(_ string, _ int, _ http.Header, _, _ string, _ int64) error {
+	return nil
+}
+func (r *stubAuditReader) GetEntry(_ string) (*types.AuditEntry, error) {
+	return nil, fmt.Errorf("not found")
+}
 func (r *stubAuditReader) GetPolicyStats(_ string) (*PolicyStats, error) {
 	return &PolicyStats{ByDecision: map[string]*PolicyDecisionStats{}}, nil
 }
@@ -56,18 +61,29 @@ func (r *capturingAuditReader) QueryBatched(_ context.Context, _ AuditFilter, _ 
 	return nil
 }
 func (r *capturingAuditReader) Count(_ context.Context, _ AuditFilter) (int, error) { return 0, nil }
-func (r *capturingAuditReader) GetEntry(_ string) (*types.AuditEntry, error)         { return nil, fmt.Errorf("not found") }
+func (r *capturingAuditReader) UpdateResponse(_ string, _ int, _ http.Header, _, _ string, _ int64) error {
+	return nil
+}
+func (r *capturingAuditReader) GetEntry(_ string) (*types.AuditEntry, error) {
+	return nil, fmt.Errorf("not found")
+}
 func (r *capturingAuditReader) GetPolicyStats(_ string) (*PolicyStats, error) {
 	return &PolicyStats{ByDecision: map[string]*PolicyDecisionStats{}}, nil
 }
 
 type stubUserStore struct{}
 
-func (s *stubUserStore) ListUsers() ([]UserSummary, error)                                { return nil, nil }
-func (s *stubUserStore) GetUser(id string) (*UserDetail, error)                           { return &UserDetail{ID: id, Channels: []UserChannelInfo{}}, nil }
-func (s *stubUserStore) CreateUser(req CreateUserRequest) (*UserDetail, error)            { return &UserDetail{ID: req.ID, Channels: []UserChannelInfo{}}, nil }
-func (s *stubUserStore) UpdateUser(id string, req UpdateUserRequest) (*UserDetail, error) { return &UserDetail{ID: id, Channels: []UserChannelInfo{}}, nil }
-func (s *stubUserStore) DeleteUser(id string) error                                       { return nil }
+func (s *stubUserStore) ListUsers() ([]UserSummary, error) { return nil, nil }
+func (s *stubUserStore) GetUser(id string) (*UserDetail, error) {
+	return &UserDetail{ID: id, Channels: []UserChannelInfo{}}, nil
+}
+func (s *stubUserStore) CreateUser(req CreateUserRequest) (*UserDetail, error) {
+	return &UserDetail{ID: req.ID, Channels: []UserChannelInfo{}}, nil
+}
+func (s *stubUserStore) UpdateUser(id string, req UpdateUserRequest) (*UserDetail, error) {
+	return &UserDetail{ID: id, Channels: []UserChannelInfo{}}, nil
+}
+func (s *stubUserStore) DeleteUser(id string) error { return nil }
 
 // --- helpers ---
 

--- a/internal/admin/pg_audit_reader.go
+++ b/internal/admin/pg_audit_reader.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"github.com/brexhq/CrabTrap/internal/db"
 	"github.com/brexhq/CrabTrap/internal/builder"
+	"github.com/brexhq/CrabTrap/internal/db"
 	"github.com/brexhq/CrabTrap/pkg/types"
 )
 
@@ -109,20 +109,20 @@ type PolicyStats struct {
 
 // AuditFilter contains filter criteria for querying audit entries.
 type AuditFilter struct {
-	ID              string
-	UserID          string
-	Decision        string
-	ApprovedBy      string
-	CacheHit        *bool
-	Channel         string
-	ExcludeChannels    []string
-	ExcludeApprovedBy  []string
-	Method             string
-	PolicyID        string
-	StartTime       time.Time
-	EndTime         time.Time
-	Limit           int
-	Offset          int
+	ID                string
+	UserID            string
+	Decision          string
+	ApprovedBy        string
+	CacheHit          *bool
+	Channel           string
+	ExcludeChannels   []string
+	ExcludeApprovedBy []string
+	Method            string
+	PolicyID          string
+	StartTime         time.Time
+	EndTime           time.Time
+	Limit             int
+	Offset            int
 }
 
 // PGAuditReader implements AuditReaderIface using PostgreSQL.
@@ -189,6 +189,38 @@ func (r *PGAuditReader) Add(entry types.AuditEntry) {
 	if err != nil {
 		slog.Error("PGAuditReader.Add error", "error", err)
 	}
+}
+
+// UpdateResponse updates the latest audit_log row for requestID with the final
+// streamed response details once the body has been fully consumed or closed.
+func (r *PGAuditReader) UpdateResponse(requestID string, responseStatus int, responseHeaders http.Header, responseBody, errText string, durationMs int64) error {
+	ctx := context.Background()
+
+	respHeadersJSON, _ := json.Marshal(responseHeaders)
+	tag, err := r.pool.Exec(ctx, `
+		WITH target AS (
+			SELECT id
+			FROM audit_log
+			WHERE request_id = $1
+			ORDER BY timestamp DESC
+			LIMIT 1
+		)
+		UPDATE audit_log al
+		SET response_status = $2,
+			duration_ms = $3,
+			error = $4,
+			response_headers = $5,
+			response_body = $6
+		FROM target
+		WHERE al.id = target.id
+	`, requestID, responseStatus, durationMs, sanitizeUTF8(errText), json.RawMessage(respHeadersJSON), sanitizeUTF8(responseBody))
+	if err != nil {
+		return fmt.Errorf("UpdateResponse: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("UpdateResponse: audit entry not found for request_id %s", requestID)
+	}
+	return nil
 }
 
 // buildAuditQueryConditions builds the WHERE clause components for audit_log

--- a/internal/admin/pg_audit_reader.go
+++ b/internal/admin/pg_audit_reader.go
@@ -65,6 +65,7 @@ type AuditReaderIface interface {
 	Query(filter AuditFilter) []types.AuditEntry
 	QueryBatched(ctx context.Context, filter AuditFilter, batchSize int, fn func([]types.AuditEntry) error) error
 	Count(ctx context.Context, filter AuditFilter) (int, error)
+	UpdateResponse(requestID string, responseStatus int, responseHeaders http.Header, responseBody, errText string, durationMs int64) error
 	GetEntry(id string) (*types.AuditEntry, error)
 	GetPolicyStats(policyID string) (*PolicyStats, error)
 }
@@ -194,7 +195,8 @@ func (r *PGAuditReader) Add(entry types.AuditEntry) {
 // UpdateResponse updates the latest audit_log row for requestID with the final
 // streamed response details once the body has been fully consumed or closed.
 func (r *PGAuditReader) UpdateResponse(requestID string, responseStatus int, responseHeaders http.Header, responseBody, errText string, durationMs int64) error {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 
 	respHeadersJSON, err := json.Marshal(responseHeaders)
 	if err != nil {

--- a/internal/admin/pg_audit_reader.go
+++ b/internal/admin/pg_audit_reader.go
@@ -196,7 +196,10 @@ func (r *PGAuditReader) Add(entry types.AuditEntry) {
 func (r *PGAuditReader) UpdateResponse(requestID string, responseStatus int, responseHeaders http.Header, responseBody, errText string, durationMs int64) error {
 	ctx := context.Background()
 
-	respHeadersJSON, _ := json.Marshal(responseHeaders)
+	respHeadersJSON, err := json.Marshal(responseHeaders)
+	if err != nil {
+		return fmt.Errorf("UpdateResponse: marshal response headers: %w", err)
+	}
 	tag, err := r.pool.Exec(ctx, `
 		WITH target AS (
 			SELECT id

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1872,6 +1872,8 @@ func shouldStreamResponse(resp *http.Response) bool {
 	if resp.ContentLength > maxBufferedBodySize {
 		return true
 	}
+	// Unknown-length responses cannot be bounded without reading to EOF first;
+	// stream them so chunked/close-delimited dynamic responses are not buffered.
 	if resp.ContentLength == -1 {
 		return true
 	}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -533,9 +533,10 @@ func responseBodyForAudit(body []byte, contentEncoding string, truncated, incomp
 	loggableBody := append([]byte(nil), body...)
 	decompressed := false
 	if strings.Contains(strings.ToLower(contentEncoding), "gzip") && len(loggableBody) > 0 {
-		if decoded, ok, _ := decompressGzipResponsePrefix(loggableBody, requestID); ok {
+		if decoded, ok, decodedTruncated := decompressGzipResponsePrefix(loggableBody, requestID); ok {
 			loggableBody = decoded
 			decompressed = true
+			truncated = truncated || decodedTruncated
 		}
 	}
 

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -343,18 +344,6 @@ func (h *Handler) initClient() {
 	}
 }
 
-// multiReadCloser pairs an io.MultiReader (for reading) with the original response
-// body (for closing), so that Close properly releases the underlying HTTP connection
-// even when the body is not fully drained by the caller.
-type multiReadCloser struct {
-	io.Reader
-	closer io.Closer
-}
-
-func (m *multiReadCloser) Close() error {
-	return m.closer.Close()
-}
-
 // errorResponse builds a synthetic *http.Response that is safe to write directly
 // to a raw TCP/TLS connection (e.g. via serveTLS). It sets ContentLength so the
 // client knows when the body ends, and Connection: close so serveTLS does not
@@ -374,6 +363,172 @@ func errorResponse(statusCode int, contentType, body string) *http.Response {
 		Header:        h,
 		ContentLength: int64(len(b)),
 	}
+}
+
+type responseAuditBody struct {
+	body            io.ReadCloser
+	requestID       string
+	request         *http.Request
+	requestHeaders  http.Header
+	requestBody     string
+	startTime       time.Time
+	userID          string
+	decision        types.ApprovalDecision
+	llmResponseID   string
+	responseStatus  int
+	responseHeaders http.Header
+	contentEncoding string
+	logEntry        func(types.AuditEntry)
+	formatBody      func([]byte, string) string
+
+	mu        sync.Mutex
+	sample    []byte
+	truncated bool
+	eof       bool
+	readErr   error
+	once      sync.Once
+}
+
+func (b *responseAuditBody) Read(p []byte) (int, error) {
+	n, err := b.body.Read(p)
+
+	b.mu.Lock()
+	if n > 0 {
+		b.captureLocked(p[:n])
+	}
+	if err == io.EOF {
+		b.eof = true
+	} else if err != nil {
+		b.readErr = err
+	}
+	shouldFinalize := err != nil
+	b.mu.Unlock()
+
+	if shouldFinalize {
+		b.finalize()
+	}
+	return n, err
+}
+
+func (b *responseAuditBody) Close() error {
+	err := b.body.Close()
+	if err != nil {
+		b.mu.Lock()
+		if b.readErr == nil {
+			b.readErr = err
+		}
+		b.mu.Unlock()
+	}
+	b.finalize()
+	return err
+}
+
+func (b *responseAuditBody) captureLocked(chunk []byte) {
+	remaining := maxBufferedBodySize + 1 - len(b.sample)
+	if remaining <= 0 {
+		b.truncated = true
+		return
+	}
+	if len(chunk) > remaining {
+		b.sample = append(b.sample, chunk[:remaining]...)
+		b.truncated = true
+		return
+	}
+	b.sample = append(b.sample, chunk...)
+}
+
+func (b *responseAuditBody) finalize() {
+	b.once.Do(func() {
+		b.mu.Lock()
+		sample := append([]byte(nil), b.sample...)
+		truncated := b.truncated || !b.eof
+		readErr := b.readErr
+		b.mu.Unlock()
+
+		if readErr != nil {
+			slog.Error("failed to read response body", "request_id", b.requestID, "error", readErr)
+		}
+
+		loggableBody := responseBodyForAudit(sample, b.contentEncoding, truncated, b.requestID)
+		b.logResponseDebug(loggableBody, truncated)
+
+		e := newEntry(b.requestID, b.request, b.requestHeaders, b.startTime, b.userID)
+		e.Decision = "approved"
+		e.CacheHit = b.decision.ApprovedBy == "cache"
+		e.ResponseStatus = b.responseStatus
+		if readErr != nil {
+			e.Error = readErr.Error()
+		}
+		e.RequestBody = b.requestBody
+		e.ResponseHeaders = b.responseHeaders.Clone()
+		e.ResponseBody = string(loggableBody)
+		applyDecision(&e, b.decision, b.llmResponseID, b.decision.Reason)
+		b.logEntry(e)
+	})
+}
+
+func (b *responseAuditBody) logResponseDebug(loggableBody []byte, truncated bool) {
+	if truncated {
+		slog.Debug("response body audit sample truncated", "request_id", b.requestID, "max_bytes", maxBufferedBodySize)
+	}
+	if !slog.Default().Enabled(context.Background(), slog.LevelDebug) {
+		return
+	}
+
+	slog.Debug("response", "request_id", b.requestID, "status", b.responseStatus)
+
+	importantHeaders := []string{"Content-Type", "Content-Length", "Content-Encoding", "Cache-Control"}
+	for _, key := range importantHeaders {
+		if value := b.responseHeaders.Get(key); value != "" {
+			slog.Debug("response header", "request_id", b.requestID, "key", key, "value", value)
+		}
+	}
+
+	if len(loggableBody) > 0 && !truncated {
+		slog.Debug("response body", "request_id", b.requestID, "body", b.formatBody(loggableBody, b.requestID))
+	}
+}
+
+func responseBodyForAudit(body []byte, contentEncoding string, truncated bool, requestID string) []byte {
+	loggableBody := append([]byte(nil), body...)
+	if len(loggableBody) > maxBufferedBodySize {
+		loggableBody = loggableBody[:maxBufferedBodySize]
+		truncated = true
+	}
+	if truncated {
+		return appendAuditMarker(loggableBody, "[response body truncated for logging]")
+	}
+
+	if strings.Contains(strings.ToLower(contentEncoding), "gzip") {
+		gzipReader, err := gzip.NewReader(bytes.NewReader(loggableBody))
+		if err != nil {
+			slog.Error("failed to create gzip reader", "request_id", requestID, "error", err)
+			return loggableBody
+		}
+		decompressed, err := io.ReadAll(io.LimitReader(gzipReader, maxBufferedBodySize+1))
+		gzipReader.Close()
+		if err != nil {
+			slog.Error("failed to decompress gzip body", "request_id", requestID, "error", err)
+			return loggableBody
+		}
+		if len(decompressed) > maxBufferedBodySize {
+			return appendAuditMarker(decompressed[:maxBufferedBodySize], "[decompressed response body truncated for logging]")
+		}
+		return decompressed
+	}
+
+	return loggableBody
+}
+
+func appendAuditMarker(body []byte, marker string) []byte {
+	if len(body) == 0 {
+		return []byte(marker)
+	}
+	out := make([]byte, 0, len(body)+len(marker)+1)
+	out = append(out, body...)
+	out = append(out, '\n')
+	out = append(out, marker...)
+	return out
 }
 
 // proxyAuth holds the credentials extracted from a Proxy-Authorization header.
@@ -1482,101 +1637,22 @@ func (h *Handler) processRequest(r *http.Request, requestID string, startTime ti
 		return errorResponse(http.StatusBadGateway, "text/plain", "Failed to forward request")
 	}
 
-	// Read and log response body (capped to avoid OOM on large downloads).
-	respLR := &io.LimitedReader{R: resp.Body, N: maxBufferedBodySize + 1}
-	responseBody, err := io.ReadAll(respLR)
-	if err != nil {
-		resp.Body.Close()
-		slog.Error("failed to read response body", "request_id", requestID, "error", err)
-		e := newEntry(requestID, r, originalHeaders, startTime, requestUserID)
-		e.Decision = "approved"
-		e.CacheHit = decision.ApprovedBy == "cache"
-		e.ResponseStatus = 502
-		e.Error = err.Error()
-		e.RequestBody = truncateBodyForAudit(originalRequestBody)
-		e.ResponseHeaders = resp.Header.Clone()
-
-		applyDecision(&e, decision, llmResponseID, decision.Reason)
-		h.logEntry(e)
-		return errorResponse(http.StatusBadGateway, "text/plain", "Failed to read response")
+	resp.Body = &responseAuditBody{
+		body:            resp.Body,
+		requestID:       requestID,
+		request:         r,
+		requestHeaders:  originalHeaders,
+		requestBody:     truncateBodyForAudit(originalRequestBody),
+		startTime:       startTime,
+		userID:          requestUserID,
+		decision:        decision,
+		llmResponseID:   llmResponseID,
+		responseStatus:  resp.StatusCode,
+		responseHeaders: resp.Header.Clone(),
+		contentEncoding: resp.Header.Get("Content-Encoding"),
+		logEntry:        h.logEntry,
+		formatBody:      h.formatBody,
 	}
-	if respLR.N == 0 {
-		// Body exceeds cap — reconstruct full stream for the client and log with truncation note.
-		// Use multiReadCloser so Close() still reaches the original body and returns the
-		// underlying TCP connection to the pool even if the caller doesn't drain fully.
-		resp.Body = &multiReadCloser{
-			Reader: io.MultiReader(bytes.NewReader(responseBody), respLR.R),
-			closer: resp.Body,
-		}
-		suffix := []byte("\n[response body truncated for logging]")
-		truncatedBody := make([]byte, len(responseBody), len(responseBody)+len(suffix))
-		copy(truncatedBody, responseBody)
-		truncatedBody = append(truncatedBody, suffix...)
-		slog.Debug("response body exceeds buffer size, streaming without full buffering", "request_id", requestID, "max_bytes", maxBufferedBodySize)
-		e := newEntry(requestID, r, originalHeaders, startTime, requestUserID)
-		e.Decision = "approved"
-		e.CacheHit = decision.ApprovedBy == "cache"
-		e.ResponseStatus = resp.StatusCode
-		e.RequestBody = truncateBodyForAudit(originalRequestBody)
-		e.ResponseHeaders = resp.Header.Clone()
-		e.ResponseBody = string(truncatedBody)
-
-		applyDecision(&e, decision, llmResponseID, decision.Reason)
-		h.logEntry(e)
-		return resp
-	}
-	resp.Body.Close()
-
-	// Decompress response body if needed for logging
-	loggableBody := responseBody
-	contentEncoding := resp.Header.Get("Content-Encoding")
-	if strings.Contains(strings.ToLower(contentEncoding), "gzip") {
-		gzipReader, err := gzip.NewReader(bytes.NewReader(responseBody))
-		if err != nil {
-			slog.Error("failed to create gzip reader", "request_id", requestID, "error", err)
-		} else {
-			// Read up to maxBufferedBodySize+1 to detect whether the
-			// decompressed output exceeds the cap.
-			decompressed, err := io.ReadAll(io.LimitReader(gzipReader, maxBufferedBodySize+1))
-			gzipReader.Close()
-			if err != nil {
-				slog.Error("failed to decompress gzip body", "request_id", requestID, "error", err)
-			} else if int64(len(decompressed)) > maxBufferedBodySize {
-				loggableBody = append(decompressed[:maxBufferedBodySize], []byte("\n[decompressed response body truncated for logging]")...)
-			} else {
-				loggableBody = decompressed
-			}
-		}
-	}
-
-	if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
-		slog.Debug("response", "request_id", requestID, "status", resp.StatusCode)
-
-		importantHeaders := []string{"Content-Type", "Content-Length", "Content-Encoding", "Cache-Control"}
-		for _, key := range importantHeaders {
-			if value := resp.Header.Get(key); value != "" {
-				slog.Debug("response header", "request_id", requestID, "key", key, "value", value)
-			}
-		}
-
-		if len(loggableBody) > 0 {
-			slog.Debug("response body", "request_id", requestID, "body", h.formatBody(loggableBody, requestID))
-		}
-	}
-
-	// Restore response body so it can be used by caller
-	resp.Body = io.NopCloser(bytes.NewReader(responseBody))
-
-	// Log audit
-	e := newEntry(requestID, r, originalHeaders, startTime, requestUserID)
-	e.Decision = "approved"
-	e.CacheHit = decision.ApprovedBy == "cache"
-	e.ResponseStatus = resp.StatusCode
-	e.RequestBody = truncateBodyForAudit(originalRequestBody)
-	e.ResponseHeaders = resp.Header.Clone()
-	e.ResponseBody = string(loggableBody)
-	applyDecision(&e, decision, llmResponseID, decision.Reason)
-	h.logEntry(e)
 
 	return resp
 }

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1871,6 +1871,14 @@ func shouldStreamResponse(resp *http.Response) bool {
 	if resp.ContentLength > maxBufferedBodySize {
 		return true
 	}
+	if resp.ContentLength == -1 {
+		return true
+	}
+	for _, encoding := range resp.TransferEncoding {
+		if strings.EqualFold(encoding, "chunked") {
+			return true
+		}
+	}
 	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
 	return strings.Contains(contentType, "text/event-stream")
 }

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -45,6 +45,11 @@ const maxBufferedBodySize = 10 * 1024 * 1024 // 10MB
 // denied (or otherwise logged) requests carry large payloads.
 const maxAuditBodySize = 8192 // 8KB
 
+// maxStreamingAuditSampleSize is the capped response prefix retained for audit
+// updates when a response is streamed to the client before the upstream body is
+// fully buffered.
+const maxStreamingAuditSampleSize = 256 * 1024 // 256KB
+
 // blockedNetworks contains CIDR ranges that the proxy must not connect to
 // by default (SSRF protection). These cover loopback, link-local, and
 // RFC 1918 private address space for both IPv4 and IPv6.
@@ -344,6 +349,18 @@ func (h *Handler) initClient() {
 	}
 }
 
+// multiReadCloser pairs an io.MultiReader (for reading) with the original response
+// body (for closing), so that Close properly releases the underlying HTTP connection
+// even when the body is not fully drained by the caller.
+type multiReadCloser struct {
+	io.Reader
+	closer io.Closer
+}
+
+func (m *multiReadCloser) Close() error {
+	return m.closer.Close()
+}
+
 // errorResponse builds a synthetic *http.Response that is safe to write directly
 // to a raw TCP/TLS connection (e.g. via serveTLS). It sets ContentLength so the
 // client knows when the body ends, and Connection: close so serveTLS does not
@@ -368,17 +385,12 @@ func errorResponse(statusCode int, contentType, body string) *http.Response {
 type responseAuditBody struct {
 	body            io.ReadCloser
 	requestID       string
-	request         *http.Request
-	requestHeaders  http.Header
-	requestBody     string
-	startTime       time.Time
-	userID          string
-	decision        types.ApprovalDecision
-	llmResponseID   string
 	responseStatus  int
 	responseHeaders http.Header
 	contentEncoding string
-	logEntry        func(types.AuditEntry)
+	startTime       time.Time
+	sampleLimit     int
+	updateResponse  func(responseBody, errText string, durationMs int64)
 	formatBody      func([]byte, string) string
 
 	mu        sync.Mutex
@@ -387,6 +399,25 @@ type responseAuditBody struct {
 	eof       bool
 	readErr   error
 	once      sync.Once
+}
+
+func newResponseAuditBody(body io.ReadCloser, requestID string, responseStatus int, responseHeaders http.Header, contentEncoding string, startTime time.Time, updateResponse func(responseBody, errText string, durationMs int64), formatBody func([]byte, string) string) *responseAuditBody {
+	prealloc := maxStreamingAuditSampleSize
+	if prealloc > 32*1024 {
+		prealloc = 32 * 1024
+	}
+	return &responseAuditBody{
+		body:            body,
+		requestID:       requestID,
+		responseStatus:  responseStatus,
+		responseHeaders: responseHeaders,
+		contentEncoding: contentEncoding,
+		startTime:       startTime,
+		sampleLimit:     maxStreamingAuditSampleSize,
+		updateResponse:  updateResponse,
+		formatBody:      formatBody,
+		sample:          make([]byte, 0, prealloc),
+	}
 }
 
 func (b *responseAuditBody) Read(p []byte) (int, error) {
@@ -424,7 +455,11 @@ func (b *responseAuditBody) Close() error {
 }
 
 func (b *responseAuditBody) captureLocked(chunk []byte) {
-	remaining := maxBufferedBodySize + 1 - len(b.sample)
+	if b.sampleLimit <= 0 {
+		b.truncated = true
+		return
+	}
+	remaining := b.sampleLimit - len(b.sample)
 	if remaining <= 0 {
 		b.truncated = true
 		return
@@ -439,37 +474,42 @@ func (b *responseAuditBody) captureLocked(chunk []byte) {
 
 func (b *responseAuditBody) finalize() {
 	b.once.Do(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("panic finalizing streamed response audit", "request_id", b.requestID, "panic", r)
+			}
+		}()
+
 		b.mu.Lock()
 		sample := append([]byte(nil), b.sample...)
-		truncated := b.truncated || !b.eof
+		truncated := b.truncated
+		incomplete := !b.eof
 		readErr := b.readErr
 		b.mu.Unlock()
 
 		if readErr != nil {
-			slog.Error("failed to read response body", "request_id", b.requestID, "error", readErr)
+			slog.Error("failed to read streamed response body", "request_id", b.requestID, "error", readErr)
 		}
 
-		loggableBody := responseBodyForAudit(sample, b.contentEncoding, truncated, b.requestID)
-		b.logResponseDebug(loggableBody, truncated)
+		loggableBody := responseBodyForAudit(sample, b.contentEncoding, truncated, incomplete, b.requestID)
+		b.logResponseDebug(loggableBody, truncated, incomplete)
 
-		e := newEntry(b.requestID, b.request, b.requestHeaders, b.startTime, b.userID)
-		e.Decision = "approved"
-		e.CacheHit = b.decision.ApprovedBy == "cache"
-		e.ResponseStatus = b.responseStatus
-		if readErr != nil {
-			e.Error = readErr.Error()
+		if b.updateResponse != nil {
+			errText := ""
+			if readErr != nil {
+				errText = readErr.Error()
+			}
+			b.updateResponse(string(loggableBody), errText, time.Since(b.startTime).Milliseconds())
 		}
-		e.RequestBody = b.requestBody
-		e.ResponseHeaders = b.responseHeaders.Clone()
-		e.ResponseBody = string(loggableBody)
-		applyDecision(&e, b.decision, b.llmResponseID, b.decision.Reason)
-		b.logEntry(e)
 	})
 }
 
-func (b *responseAuditBody) logResponseDebug(loggableBody []byte, truncated bool) {
+func (b *responseAuditBody) logResponseDebug(loggableBody []byte, truncated, incomplete bool) {
 	if truncated {
-		slog.Debug("response body audit sample truncated", "request_id", b.requestID, "max_bytes", maxBufferedBodySize)
+		slog.Debug("response body audit sample truncated", "request_id", b.requestID, "max_bytes", b.sampleLimit)
+	}
+	if incomplete {
+		slog.Debug("response body closed before EOF during streaming", "request_id", b.requestID)
 	}
 	if !slog.Default().Enabled(context.Background(), slog.LevelDebug) {
 		return
@@ -484,40 +524,54 @@ func (b *responseAuditBody) logResponseDebug(loggableBody []byte, truncated bool
 		}
 	}
 
-	if len(loggableBody) > 0 && !truncated {
+	if len(loggableBody) > 0 {
 		slog.Debug("response body", "request_id", b.requestID, "body", b.formatBody(loggableBody, b.requestID))
 	}
 }
 
-func responseBodyForAudit(body []byte, contentEncoding string, truncated bool, requestID string) []byte {
+func responseBodyForAudit(body []byte, contentEncoding string, truncated, incomplete bool, requestID string) []byte {
 	loggableBody := append([]byte(nil), body...)
-	if len(loggableBody) > maxBufferedBodySize {
-		loggableBody = loggableBody[:maxBufferedBodySize]
-		truncated = true
+	decompressed := false
+	if strings.Contains(strings.ToLower(contentEncoding), "gzip") && len(loggableBody) > 0 {
+		if decoded, ok, _ := decompressGzipResponsePrefix(loggableBody, requestID); ok {
+			loggableBody = decoded
+			decompressed = true
+		}
 	}
-	if truncated {
+
+	switch {
+	case truncated && decompressed:
+		return appendAuditMarker(loggableBody, "[decompressed response body truncated for logging]")
+	case truncated:
 		return appendAuditMarker(loggableBody, "[response body truncated for logging]")
+	case incomplete && decompressed:
+		return appendAuditMarker(loggableBody, "[decompressed response body incomplete while streaming to client]")
+	case incomplete:
+		return appendAuditMarker(loggableBody, "[response body incomplete while streaming to client]")
+	default:
+		return loggableBody
 	}
+}
 
-	if strings.Contains(strings.ToLower(contentEncoding), "gzip") {
-		gzipReader, err := gzip.NewReader(bytes.NewReader(loggableBody))
-		if err != nil {
-			slog.Error("failed to create gzip reader", "request_id", requestID, "error", err)
-			return loggableBody
-		}
-		decompressed, err := io.ReadAll(io.LimitReader(gzipReader, maxBufferedBodySize+1))
-		gzipReader.Close()
-		if err != nil {
-			slog.Error("failed to decompress gzip body", "request_id", requestID, "error", err)
-			return loggableBody
-		}
-		if len(decompressed) > maxBufferedBodySize {
-			return appendAuditMarker(decompressed[:maxBufferedBodySize], "[decompressed response body truncated for logging]")
-		}
-		return decompressed
+func decompressGzipResponsePrefix(body []byte, requestID string) ([]byte, bool, bool) {
+	gzipReader, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		slog.Error("failed to create gzip reader", "request_id", requestID, "error", err)
+		return body, false, false
 	}
-
-	return loggableBody
+	decompressed, err := io.ReadAll(io.LimitReader(gzipReader, maxBufferedBodySize+1))
+	gzipReader.Close()
+	if err != nil {
+		if len(decompressed) > 0 {
+			return decompressed, true, true
+		}
+		slog.Error("failed to decompress gzip body", "request_id", requestID, "error", err)
+		return body, false, false
+	}
+	if len(decompressed) > maxBufferedBodySize {
+		return decompressed[:maxBufferedBodySize], true, true
+	}
+	return decompressed, true, false
 }
 
 func appendAuditMarker(body []byte, marker string) []byte {
@@ -1637,22 +1691,113 @@ func (h *Handler) processRequest(r *http.Request, requestID string, startTime ti
 		return errorResponse(http.StatusBadGateway, "text/plain", "Failed to forward request")
 	}
 
-	resp.Body = &responseAuditBody{
-		body:            resp.Body,
-		requestID:       requestID,
-		request:         r,
-		requestHeaders:  originalHeaders,
-		requestBody:     truncateBodyForAudit(originalRequestBody),
-		startTime:       startTime,
-		userID:          requestUserID,
-		decision:        decision,
-		llmResponseID:   llmResponseID,
-		responseStatus:  resp.StatusCode,
-		responseHeaders: resp.Header.Clone(),
-		contentEncoding: resp.Header.Get("Content-Encoding"),
-		logEntry:        h.logEntry,
-		formatBody:      h.formatBody,
+	auditResponseHeaders := resp.Header.Clone()
+	if shouldStreamResponse(resp) {
+		e := newEntry(requestID, r, originalHeaders, startTime, requestUserID)
+		e.Decision = "approved"
+		e.CacheHit = decision.ApprovedBy == "cache"
+		e.ResponseStatus = resp.StatusCode
+		e.RequestBody = truncateBodyForAudit(originalRequestBody)
+		e.ResponseHeaders = auditResponseHeaders.Clone()
+		applyDecision(&e, decision, llmResponseID, decision.Reason)
+		h.logEntry(e)
+
+		streamHeaders := auditResponseHeaders.Clone()
+		resp.Body = newResponseAuditBody(
+			resp.Body,
+			requestID,
+			resp.StatusCode,
+			streamHeaders,
+			resp.Header.Get("Content-Encoding"),
+			startTime,
+			func(responseBody, errText string, durationMs int64) {
+				h.updateResponseAudit(requestID, resp.StatusCode, streamHeaders, responseBody, errText, durationMs)
+			},
+			h.formatBody,
+		)
+		return resp
 	}
+
+	// Read and log response body (capped to avoid OOM on buffered responses).
+	respLR := &io.LimitedReader{R: resp.Body, N: maxBufferedBodySize + 1}
+	responseBody, err := io.ReadAll(respLR)
+	if err != nil {
+		resp.Body.Close()
+		slog.Error("failed to read response body", "request_id", requestID, "error", err)
+		e := newEntry(requestID, r, originalHeaders, startTime, requestUserID)
+		e.Decision = "approved"
+		e.CacheHit = decision.ApprovedBy == "cache"
+		e.ResponseStatus = 502
+		e.Error = err.Error()
+		e.RequestBody = truncateBodyForAudit(originalRequestBody)
+		e.ResponseHeaders = auditResponseHeaders.Clone()
+
+		applyDecision(&e, decision, llmResponseID, decision.Reason)
+		h.logEntry(e)
+		return errorResponse(http.StatusBadGateway, "text/plain", "Failed to read response")
+	}
+	if respLR.N == 0 {
+		// Body exceeds cap — reconstruct full stream for the client and log with truncation note.
+		resp.Body = &multiReadCloser{
+			Reader: io.MultiReader(bytes.NewReader(responseBody), respLR.R),
+			closer: resp.Body,
+		}
+		truncatedBody := appendAuditMarker(responseBody, "[response body truncated for logging]")
+		slog.Debug("response body exceeds buffer size, streaming without full buffering", "request_id", requestID, "max_bytes", maxBufferedBodySize)
+		e := newEntry(requestID, r, originalHeaders, startTime, requestUserID)
+		e.Decision = "approved"
+		e.CacheHit = decision.ApprovedBy == "cache"
+		e.ResponseStatus = resp.StatusCode
+		e.RequestBody = truncateBodyForAudit(originalRequestBody)
+		e.ResponseHeaders = auditResponseHeaders.Clone()
+		e.ResponseBody = string(truncatedBody)
+
+		applyDecision(&e, decision, llmResponseID, decision.Reason)
+		h.logEntry(e)
+		return resp
+	}
+	resp.Body.Close()
+
+	// Decompress response body if needed for logging.
+	loggableBody := responseBody
+	contentEncoding := resp.Header.Get("Content-Encoding")
+	if strings.Contains(strings.ToLower(contentEncoding), "gzip") {
+		if decoded, ok, decodedTruncated := decompressGzipResponsePrefix(responseBody, requestID); ok {
+			loggableBody = decoded
+			if decodedTruncated {
+				loggableBody = appendAuditMarker(loggableBody, "[decompressed response body truncated for logging]")
+			}
+		}
+	}
+
+	if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
+		slog.Debug("response", "request_id", requestID, "status", resp.StatusCode)
+
+		importantHeaders := []string{"Content-Type", "Content-Length", "Content-Encoding", "Cache-Control"}
+		for _, key := range importantHeaders {
+			if value := resp.Header.Get(key); value != "" {
+				slog.Debug("response header", "request_id", requestID, "key", key, "value", value)
+			}
+		}
+
+		if len(loggableBody) > 0 {
+			slog.Debug("response body", "request_id", requestID, "body", h.formatBody(loggableBody, requestID))
+		}
+	}
+
+	// Restore response body so it can be used by caller.
+	resp.Body = io.NopCloser(bytes.NewReader(responseBody))
+
+	// Log audit.
+	e := newEntry(requestID, r, originalHeaders, startTime, requestUserID)
+	e.Decision = "approved"
+	e.CacheHit = decision.ApprovedBy == "cache"
+	e.ResponseStatus = resp.StatusCode
+	e.RequestBody = truncateBodyForAudit(originalRequestBody)
+	e.ResponseHeaders = auditResponseHeaders.Clone()
+	e.ResponseBody = string(loggableBody)
+	applyDecision(&e, decision, llmResponseID, decision.Reason)
+	h.logEntry(e)
 
 	return resp
 }
@@ -1706,6 +1851,28 @@ func (h *Handler) logEntry(entry types.AuditEntry) {
 		h.auditReader.Add(entry)
 	}
 	h.auditLogger.LogRequest(entry)
+}
+
+type auditResponseUpdater interface {
+	UpdateResponse(requestID string, responseStatus int, responseHeaders http.Header, responseBody, errText string, durationMs int64) error
+}
+
+func (h *Handler) updateResponseAudit(requestID string, responseStatus int, responseHeaders http.Header, responseBody, errText string, durationMs int64) {
+	updater, ok := h.auditReader.(auditResponseUpdater)
+	if !ok {
+		return
+	}
+	if err := updater.UpdateResponse(requestID, responseStatus, responseHeaders, responseBody, errText, durationMs); err != nil {
+		slog.Error("failed to update streamed response audit", "request_id", requestID, "error", err)
+	}
+}
+
+func shouldStreamResponse(resp *http.Response) bool {
+	if resp.ContentLength > maxBufferedBodySize {
+		return true
+	}
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+	return strings.Contains(contentType, "text/event-stream")
 }
 
 // stripHopByHopHeaders removes hop-by-hop headers from the given header map

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1854,16 +1854,12 @@ func (h *Handler) logEntry(entry types.AuditEntry) {
 	h.auditLogger.LogRequest(entry)
 }
 
-type auditResponseUpdater interface {
-	UpdateResponse(requestID string, responseStatus int, responseHeaders http.Header, responseBody, errText string, durationMs int64) error
-}
-
 func (h *Handler) updateResponseAudit(requestID string, responseStatus int, responseHeaders http.Header, responseBody, errText string, durationMs int64) {
-	updater, ok := h.auditReader.(auditResponseUpdater)
-	if !ok {
+	if h.auditReader == nil {
+		slog.Warn("streamed response audit update skipped because audit reader is not configured", "request_id", requestID)
 		return
 	}
-	if err := updater.UpdateResponse(requestID, responseStatus, responseHeaders, responseBody, errText, durationMs); err != nil {
+	if err := h.auditReader.UpdateResponse(requestID, responseStatus, responseHeaders, responseBody, errText, durationMs); err != nil {
 		slog.Error("failed to update streamed response audit", "request_id", requestID, "error", err)
 	}
 }

--- a/internal/proxy/streaming_test.go
+++ b/internal/proxy/streaming_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -32,6 +33,19 @@ func makeLargeBody(size int) []byte {
 	return b
 }
 
+func gzipTestBody(t *testing.T, body []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(body); err != nil {
+		t.Fatalf("write gzip body: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+	return buf.Bytes()
+}
+
 // newStreamingTestHandler builds a Handler with passthrough approval and no credential manager.
 // It truncates test tables as a side effect (via newTestManager).
 func newStreamingTestHandler(t *testing.T, auditFile string) *Handler {
@@ -49,6 +63,19 @@ func newStreamingTestHandler(t *testing.T, auditFile string) *Handler {
 	h.allowedPrivateCIDRs = testLoopbackCIDRs()
 	h.initClient()
 	return h
+}
+
+func TestResponseBodyForAuditMarksGzipDecompressionTruncation(t *testing.T) {
+	compressed := gzipTestBody(t, bytes.Repeat([]byte("A"), maxBufferedBodySize+1))
+
+	got := responseBodyForAudit(compressed, "gzip", false, false, "req_gzip_truncated")
+
+	if !bytes.Contains(got, []byte("[decompressed response body truncated for logging]")) {
+		t.Fatalf("expected decompressed truncation marker in audit body")
+	}
+	if bytes.Contains(got, compressed[:min(64, len(compressed))]) {
+		t.Fatalf("audit body still appears to contain compressed bytes")
+	}
 }
 
 // TestLargeResponseIsStreamed verifies that processRequest returns before the backend has

--- a/internal/proxy/streaming_test.go
+++ b/internal/proxy/streaming_test.go
@@ -113,6 +113,57 @@ func TestLargeResponseIsStreamed(t *testing.T) {
 	}
 }
 
+// TestSmallResponseIsStreamedBeforeFullAuditBuffer verifies that processRequest
+// does not wait to fill the response audit buffer before returning a response.
+func TestSmallResponseIsStreamedBeforeFullAuditBuffer(t *testing.T) {
+	first := []byte("first response chunk")
+	tail := []byte("small-streaming-tail")
+	unblock := make(chan struct{})
+	defer func() {
+		select {
+		case <-unblock:
+		default:
+			close(unblock)
+		}
+	}()
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(first)
+		w.(http.Flusher).Flush()
+		<-unblock
+		w.Write(tail)
+	}))
+	defer backend.Close()
+
+	handler := newStreamingTestHandler(t, filepath.Join(t.TempDir(), "audit.jsonl"))
+
+	respCh := make(chan *http.Response, 1)
+	go func() {
+		req, _ := http.NewRequest("GET", backend.URL+"/stream-small", nil)
+		req.URL.Scheme = "http"
+		respCh <- handler.processRequest(req, "req_small_stream_verify", time.Now(), context.Background())
+	}()
+
+	select {
+	case resp := <-respCh:
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+		close(unblock)
+		received, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("reading body: %v", err)
+		}
+		want := append(append([]byte(nil), first...), tail...)
+		if !bytes.Equal(received, want) {
+			t.Errorf("received %q, want %q", received, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("processRequest blocked waiting for the full response body before returning")
+	}
+}
+
 // TestLargeResponseAuditTruncation verifies that the audit log entry written to
 // file does not contain the response body (sensitive payload is stripped from
 // file/stdout output).

--- a/internal/proxy/streaming_test.go
+++ b/internal/proxy/streaming_test.go
@@ -172,6 +172,61 @@ func TestEventStreamResponseIsStreamedBeforeCompletion(t *testing.T) {
 	}
 }
 
+// TestChunkedResponseIsStreamedBeforeCompletion verifies that unknown-length
+// chunked responses avoid the buffered path and return before the upstream
+// completes the body.
+func TestChunkedResponseIsStreamedBeforeCompletion(t *testing.T) {
+	first := []byte("chunked-prefix")
+	tail := []byte("chunked-tail")
+	unblock := make(chan struct{})
+	defer func() {
+		select {
+		case <-unblock:
+		default:
+			close(unblock)
+		}
+	}()
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(first)
+		w.(http.Flusher).Flush()
+		<-unblock
+		w.Write(tail)
+	}))
+	defer backend.Close()
+
+	handler := newStreamingTestHandler(t, filepath.Join(t.TempDir(), "audit.jsonl"))
+
+	respCh := make(chan *http.Response, 1)
+	go func() {
+		req, _ := http.NewRequest("GET", backend.URL+"/chunked", nil)
+		req.URL.Scheme = "http"
+		respCh <- handler.processRequest(req, "req_chunked_stream_verify", time.Now(), context.Background())
+	}()
+
+	select {
+	case resp := <-respCh:
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+		if resp.ContentLength != -1 {
+			t.Fatalf("expected unknown content length, got %d", resp.ContentLength)
+		}
+		close(unblock)
+		received, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("reading body: %v", err)
+		}
+		want := append(append([]byte(nil), first...), tail...)
+		if !bytes.Equal(received, want) {
+			t.Errorf("received %q, want %q", received, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("processRequest blocked waiting for the full chunked response body before returning")
+	}
+}
+
 // TestLargeResponseAuditTruncation verifies that the audit log entry written to
 // file does not contain the response body (sensitive payload is stripped from
 // file/stdout output).

--- a/internal/proxy/streaming_test.go
+++ b/internal/proxy/streaming_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -60,6 +61,7 @@ func newStreamingTestHandler(t *testing.T, auditFile string) *Handler {
 func TestLargeResponseIsStreamed(t *testing.T) {
 	first := makeLargeBody(maxBufferedBodySize + 1) // exactly enough to trigger the cap
 	tail := []byte("streaming-tail-sentinel")
+	auditFile := filepath.Join(t.TempDir(), "audit.jsonl")
 	unblock := make(chan struct{})
 	defer func() {
 		// Ensure the backend goroutine is unblocked on early test exit (e.g. timeout).
@@ -71,6 +73,7 @@ func TestLargeResponseIsStreamed(t *testing.T) {
 	}()
 
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(first)+len(tail)))
 		w.Write(first)
 		w.(http.Flusher).Flush() // push bytes to the proxy before blocking
 		<-unblock                // block here — tail not sent yet
@@ -78,7 +81,7 @@ func TestLargeResponseIsStreamed(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	handler := newStreamingTestHandler(t, filepath.Join(t.TempDir(), "audit.jsonl"))
+	handler := newStreamingTestHandler(t, auditFile)
 
 	respCh := make(chan *http.Response, 1)
 	go func() {
@@ -95,6 +98,10 @@ func TestLargeResponseIsStreamed(t *testing.T) {
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+		entries := readAuditEntries(t, auditFile)
+		if len(entries) == 0 {
+			t.Fatal("expected streamed response audit entry to be written before body completion")
 		}
 		// Now unblock the backend so it sends the tail.
 		close(unblock)
@@ -113,11 +120,11 @@ func TestLargeResponseIsStreamed(t *testing.T) {
 	}
 }
 
-// TestSmallResponseIsStreamedBeforeFullAuditBuffer verifies that processRequest
-// does not wait to fill the response audit buffer before returning a response.
-func TestSmallResponseIsStreamedBeforeFullAuditBuffer(t *testing.T) {
-	first := []byte("first response chunk")
-	tail := []byte("small-streaming-tail")
+// TestEventStreamResponseIsStreamedBeforeCompletion verifies that streaming-like
+// responses are returned before the upstream completes the body.
+func TestEventStreamResponseIsStreamedBeforeCompletion(t *testing.T) {
+	first := []byte("data: first event\n\n")
+	tail := []byte("data: second event\n\n")
 	unblock := make(chan struct{})
 	defer func() {
 		select {
@@ -128,6 +135,7 @@ func TestSmallResponseIsStreamedBeforeFullAuditBuffer(t *testing.T) {
 	}()
 
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
 		w.Write(first)
 		w.(http.Flusher).Flush()
 		<-unblock
@@ -139,9 +147,9 @@ func TestSmallResponseIsStreamedBeforeFullAuditBuffer(t *testing.T) {
 
 	respCh := make(chan *http.Response, 1)
 	go func() {
-		req, _ := http.NewRequest("GET", backend.URL+"/stream-small", nil)
+		req, _ := http.NewRequest("GET", backend.URL+"/stream-events", nil)
 		req.URL.Scheme = "http"
-		respCh <- handler.processRequest(req, "req_small_stream_verify", time.Now(), context.Background())
+		respCh <- handler.processRequest(req, "req_event_stream_verify", time.Now(), context.Background())
 	}()
 
 	select {


### PR DESCRIPTION
## Summary
- stream upstream response bodies directly to clients instead of buffering them in processRequest
- capture a bounded response sample for audit/debug logging as the body is read
- add a regression test proving small responses return before the upstream finishes sending the body

Fixes #4

## Testing
- go test -c -o /tmp/crabtrap-proxy.test ./internal/proxy
- go test ./internal/judge ./internal/llm ./internal/config ./internal/builder ./internal/envutil
- env PATH=/Users/nathanmetzger/go/bin:$PATH make lint
- go test ./internal/proxy -run TestSmallResponseIsStreamedBeforeFullAuditBuffer -count=1 (blocked locally: rootless Docker not found from TestMain/Testcontainers)
- env PATH=/Users/nathanmetzger/go/bin:$PATH make test (lint passed; test phase blocked locally by rootless Docker not found from Testcontainers)