### PR TITLE
Fix Makefile help to reference make build instead of removed build-with-web target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ help:
 	@echo "  make dev-backend        # Backend only in dev mode"
 	@echo ""
 	@echo "Production deployment:"
-	@echo "  make build-with-web     # Creates single binary with embedded UI"
+	@echo "  make build              # Creates single binary with embedded UI"
 	@echo "  ./gateway               # Run production binary"
 	@echo ""
 	@echo "If you get TLS certificate errors:"


### PR DESCRIPTION
## Summary

`make help` advertises a `build-with-web` target that does not exist. Running it fails with `No rule to make target`. This one-line fix points the help text at `make build`, which already chains `build-web` and `build-go` to produce the embedded-UI binary the text describes.

## Why this matters

`AGENTS.md:49` already calls this out:

> Use `make build`, not older `make build-with-web` references that still appear in some docs.

Leaving the stale line in `make help` means anyone following the help output for a production build hits a dead target on their first try.

## Changes

`Makefile:214`:

```diff
-	@echo "  make build-with-web     # Creates single binary with embedded UI"
+	@echo "  make build              # Creates single binary with embedded UI"
```

Column alignment of the trailing `#` comment is preserved.

## Testing

- `make help` now prints `make build` in the Production deployment section.
- `grep -rn build-with-web` returns only `AGENTS.md:49` (the explicit callout, intentionally left in place).
- No Go source, tests, or build targets touched.

## Demo

![make help before and after](https://files.catbox.moe/191mi3.gif)

Frame 1 (BEFORE): `make help` on upstream/main still shows `make build-with-web`, and `make build-with-web` fails with `No rule to make target`.
Frame 2 (AFTER): `make help` shows `make build`, and `make -n build` confirms the target chains `build-web` + `go build`.

---

This contribution was developed with AI assistance.
