### PR TITLE
Trim live audit event payloads

### DIFF
--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -14,6 +15,7 @@ import (
 type Logger struct {
 	slogger    *slog.Logger
 	file       *os.File // non-nil when writing to a file (for Close/Sync)
+	console    bool
 	mu         sync.Mutex
 	dispatcher *notifications.Dispatcher
 }
@@ -36,6 +38,7 @@ func NewLogger(output string) (*Logger, error) {
 	}
 	l := &Logger{
 		slogger: slog.New(slog.NewJSONHandler(writer, &slog.HandlerOptions{})),
+		console: writer == os.Stdout || writer == os.Stderr,
 	}
 	if writer != os.Stdout && writer != os.Stderr {
 		l.file = writer
@@ -66,26 +69,31 @@ func (l *Logger) LogRequest(entry types.AuditEntry) {
 		})
 	}
 
-	// Strip sensitive request/response payload data from file/stderr
-	// output. Full data remains in the database for authenticated
-	// admin access via the web UI.
+	logEntry := entry
+	if l.shouldStripBodiesInStructuredOutput() {
+		logEntry.RequestBody = ""
+		logEntry.ResponseBody = ""
+	}
+
 	l.slogger.Info("audit",
-		"timestamp", entry.Timestamp,
-		"request_id", entry.RequestID,
-		"user_id", entry.UserID,
-		"method", entry.Method,
-		"url", entry.URL,
-		"operation", entry.Operation,
-		"decision", entry.Decision,
-		"cache_hit", entry.CacheHit,
-		"approved_by", entry.ApprovedBy,
-		"approved_at", entry.ApprovedAt,
-		"channel", entry.Channel,
-		"response_status", entry.ResponseStatus,
-		"duration_ms", entry.DurationMs,
-		"error", entry.Error,
-		"llm_response_id", entry.LLMResponseID,
-		"llm_policy_id", entry.LLMPolicyID,
+		"timestamp", logEntry.Timestamp,
+		"request_id", logEntry.RequestID,
+		"user_id", logEntry.UserID,
+		"method", logEntry.Method,
+		"url", logEntry.URL,
+		"operation", logEntry.Operation,
+		"decision", logEntry.Decision,
+		"cache_hit", logEntry.CacheHit,
+		"approved_by", logEntry.ApprovedBy,
+		"approved_at", logEntry.ApprovedAt,
+		"channel", logEntry.Channel,
+		"response_status", logEntry.ResponseStatus,
+		"duration_ms", logEntry.DurationMs,
+		"error", logEntry.Error,
+		"request_body", logEntry.RequestBody,
+		"response_body", logEntry.ResponseBody,
+		"llm_response_id", logEntry.LLMResponseID,
+		"llm_policy_id", logEntry.LLMPolicyID,
 	)
 
 	if l.file != nil {
@@ -99,4 +107,8 @@ func (l *Logger) Close() error {
 		return l.file.Close()
 	}
 	return nil
+}
+
+func (l *Logger) shouldStripBodiesInStructuredOutput() bool {
+	return l.console && !slog.Default().Enabled(context.Background(), slog.LevelDebug)
 }

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -57,9 +57,12 @@ func (l *Logger) LogRequest(entry types.AuditEntry) {
 	l.mu.Unlock()
 
 	if dispatcher != nil {
+		eventEntry := entry
+		eventEntry.RequestBody = ""
+		eventEntry.ResponseBody = ""
 		dispatcher.Broadcast(notifications.Event{
 			Type: notifications.EventAuditEntry,
-			Data: &entry,
+			Data: &eventEntry,
 		})
 	}
 

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -63,6 +63,8 @@ func (l *Logger) LogRequest(entry types.AuditEntry) {
 		eventEntry := entry
 		eventEntry.RequestBody = ""
 		eventEntry.ResponseBody = ""
+		eventEntry.RequestHeaders = nil
+		eventEntry.ResponseHeaders = nil
 		dispatcher.Broadcast(notifications.Event{
 			Type: notifications.EventAuditEntry,
 			Data: &eventEntry,

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -64,11 +64,20 @@ func TestLogRequestBroadcastsAuditEntryWithoutBodies(t *testing.T) {
 	if got.ResponseBody != "" {
 		t.Fatalf("broadcast response body = %q, want empty", got.ResponseBody)
 	}
+	if len(got.RequestHeaders) != 0 {
+		t.Fatalf("broadcast request headers = %v, want empty", got.RequestHeaders)
+	}
+	if len(got.ResponseHeaders) != 0 {
+		t.Fatalf("broadcast response headers = %v, want empty", got.ResponseHeaders)
+	}
 	if got.RequestID != entry.RequestID {
 		t.Fatalf("broadcast request ID = %q, want %q", got.RequestID, entry.RequestID)
 	}
 	if entry.RequestBody == "" || entry.ResponseBody == "" {
 		t.Fatal("LogRequest mutated the caller's audit entry bodies")
+	}
+	if len(entry.RequestHeaders) == 0 || len(entry.ResponseHeaders) == 0 {
+		t.Fatal("LogRequest mutated the caller's audit entry headers")
 	}
 }
 
@@ -126,8 +135,15 @@ func sampleAuditEntry() types.AuditEntry {
 		Operation:      "READ",
 		Decision:       "approved",
 		ResponseStatus: http.StatusOK,
-		RequestBody:    "large request body",
-		ResponseBody:   "large response body",
+		RequestHeaders: http.Header{
+			"Authorization": []string{"Bearer secret-token"},
+			"Cookie":        []string{"session=secret"},
+		},
+		RequestBody: "large request body",
+		ResponseHeaders: http.Header{
+			"Set-Cookie": []string{"session=secret"},
+		},
+		ResponseBody: "large response body",
 	}
 }
 

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -1,0 +1,80 @@
+package audit
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/brexhq/CrabTrap/internal/notifications"
+	"github.com/brexhq/CrabTrap/pkg/types"
+)
+
+type captureChannel struct {
+	mu    sync.Mutex
+	event notifications.Event
+}
+
+func (c *captureChannel) Name() string {
+	return "capture"
+}
+
+func (c *captureChannel) Notify(event notifications.Event) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.event = event
+	return nil
+}
+
+func (c *captureChannel) eventData(t *testing.T) *types.AuditEntry {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.event.Data.(*types.AuditEntry)
+	if !ok {
+		t.Fatalf("event data type = %T, want *types.AuditEntry", c.event.Data)
+	}
+	return entry
+}
+
+func TestLogRequestBroadcastsAuditEntryWithoutBodies(t *testing.T) {
+	logger, err := NewLogger(t.TempDir() + "/audit.jsonl")
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	defer logger.Close()
+
+	dispatcher := notifications.NewDispatcher()
+	channel := &captureChannel{}
+	dispatcher.RegisterChannel(channel)
+	logger.SetDispatcher(dispatcher)
+
+	entry := types.AuditEntry{
+		Timestamp:      time.Now(),
+		RequestID:      "req_large_payload",
+		Method:         "GET",
+		URL:            "https://api.example.test/v1/items",
+		Operation:      "READ",
+		Decision:       "approved",
+		ResponseStatus: http.StatusOK,
+		RequestBody:    "large request body",
+		ResponseBody:   "large response body",
+	}
+
+	logger.LogRequest(entry)
+
+	got := channel.eventData(t)
+	if got.RequestBody != "" {
+		t.Fatalf("broadcast request body = %q, want empty", got.RequestBody)
+	}
+	if got.ResponseBody != "" {
+		t.Fatalf("broadcast response body = %q, want empty", got.ResponseBody)
+	}
+	if got.RequestID != entry.RequestID {
+		t.Fatalf("broadcast request ID = %q, want %q", got.RequestID, entry.RequestID)
+	}
+
+	if entry.RequestBody == "" || entry.ResponseBody == "" {
+		t.Fatal("LogRequest mutated the caller's audit entry bodies")
+	}
+}

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -1,7 +1,12 @@
 package audit
 
 import (
+	"encoding/json"
+	"io"
+	"log/slog"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -38,7 +43,7 @@ func (c *captureChannel) eventData(t *testing.T) *types.AuditEntry {
 }
 
 func TestLogRequestBroadcastsAuditEntryWithoutBodies(t *testing.T) {
-	logger, err := NewLogger(t.TempDir() + "/audit.jsonl")
+	logger, err := NewLogger(filepath.Join(t.TempDir(), "audit.jsonl"))
 	if err != nil {
 		t.Fatalf("NewLogger: %v", err)
 	}
@@ -49,18 +54,7 @@ func TestLogRequestBroadcastsAuditEntryWithoutBodies(t *testing.T) {
 	dispatcher.RegisterChannel(channel)
 	logger.SetDispatcher(dispatcher)
 
-	entry := types.AuditEntry{
-		Timestamp:      time.Now(),
-		RequestID:      "req_large_payload",
-		Method:         "GET",
-		URL:            "https://api.example.test/v1/items",
-		Operation:      "READ",
-		Decision:       "approved",
-		ResponseStatus: http.StatusOK,
-		RequestBody:    "large request body",
-		ResponseBody:   "large response body",
-	}
-
+	entry := sampleAuditEntry()
 	logger.LogRequest(entry)
 
 	got := channel.eventData(t)
@@ -73,8 +67,140 @@ func TestLogRequestBroadcastsAuditEntryWithoutBodies(t *testing.T) {
 	if got.RequestID != entry.RequestID {
 		t.Fatalf("broadcast request ID = %q, want %q", got.RequestID, entry.RequestID)
 	}
-
 	if entry.RequestBody == "" || entry.ResponseBody == "" {
 		t.Fatal("LogRequest mutated the caller's audit entry bodies")
+	}
+}
+
+func TestLogRequestWritesBodiesToFileOutput(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	logger, err := NewLogger(path)
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	defer logger.Close()
+
+	entry := sampleAuditEntry()
+	logger.LogRequest(entry)
+
+	record := readStructuredAuditRecord(t, path)
+	if got := recordString(t, record, "request_body"); got != entry.RequestBody {
+		t.Fatalf("request_body = %q, want %q", got, entry.RequestBody)
+	}
+	if got := recordString(t, record, "response_body"); got != entry.ResponseBody {
+		t.Fatalf("response_body = %q, want %q", got, entry.ResponseBody)
+	}
+}
+
+func TestLogRequestStripsBodiesOnStdoutWhenDebugDisabled(t *testing.T) {
+	output := captureStdoutAuditLog(t, false, sampleAuditEntry())
+	record := decodeStructuredAuditRecord(t, output)
+
+	if got := recordString(t, record, "request_body"); got != "" {
+		t.Fatalf("request_body = %q, want empty", got)
+	}
+	if got := recordString(t, record, "response_body"); got != "" {
+		t.Fatalf("response_body = %q, want empty", got)
+	}
+}
+
+func TestLogRequestKeepsBodiesOnStdoutWhenDebugEnabled(t *testing.T) {
+	entry := sampleAuditEntry()
+	output := captureStdoutAuditLog(t, true, entry)
+	record := decodeStructuredAuditRecord(t, output)
+
+	if got := recordString(t, record, "request_body"); got != entry.RequestBody {
+		t.Fatalf("request_body = %q, want %q", got, entry.RequestBody)
+	}
+	if got := recordString(t, record, "response_body"); got != entry.ResponseBody {
+		t.Fatalf("response_body = %q, want %q", got, entry.ResponseBody)
+	}
+}
+
+func sampleAuditEntry() types.AuditEntry {
+	return types.AuditEntry{
+		Timestamp:      time.Unix(1710000000, 0).UTC(),
+		RequestID:      "req_large_payload",
+		Method:         http.MethodGet,
+		URL:            "https://api.example.test/v1/items",
+		Operation:      "READ",
+		Decision:       "approved",
+		ResponseStatus: http.StatusOK,
+		RequestBody:    "large request body",
+		ResponseBody:   "large response body",
+	}
+}
+
+func readStructuredAuditRecord(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	return decodeStructuredAuditRecord(t, data)
+}
+
+func decodeStructuredAuditRecord(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	var record map[string]any
+	if err := json.Unmarshal(data, &record); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	return record
+}
+
+func recordString(t *testing.T, record map[string]any, key string) string {
+	t.Helper()
+	value, ok := record[key]
+	if !ok || value == nil {
+		return ""
+	}
+	s, ok := value.(string)
+	if !ok {
+		t.Fatalf("%s type = %T, want string", key, value)
+	}
+	return s
+}
+
+func captureStdoutAuditLog(t *testing.T, debug bool, entry types.AuditEntry) []byte {
+	t.Helper()
+
+	restoreDefault := captureDefaultLogger(t, debug)
+	defer restoreDefault()
+
+	oldStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = writer
+	defer func() { os.Stdout = oldStdout }()
+
+	logger, err := NewLogger("stdout")
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+
+	logger.LogRequest(entry)
+	writer.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	return data
+}
+
+func captureDefaultLogger(t *testing.T, debug bool) func() {
+	t.Helper()
+
+	old := slog.Default()
+	level := slog.LevelInfo
+	if debug {
+		level = slog.LevelDebug
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: level})))
+	return func() {
+		slog.SetDefault(old)
 	}
 }

--- a/internal/proxy/streaming_test.go
+++ b/internal/proxy/streaming_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -255,9 +254,9 @@ func TestChunkedResponseIsStreamedBeforeCompletion(t *testing.T) {
 	}
 }
 
-// TestLargeResponseAuditTruncation verifies that the file audit output preserves
-// the capped response body with a truncation marker.
-func TestLargeResponseAuditTruncation(t *testing.T) {
+// TestStreamedLargeResponseFileAuditWritesInitialEntry verifies that streamed
+// responses keep the early file audit entry from the merged streaming path.
+func TestStreamedLargeResponseFileAuditWritesInitialEntry(t *testing.T) {
 	data := makeLargeBody(largeBodySize)
 	auditFile := filepath.Join(t.TempDir(), "audit.jsonl")
 
@@ -272,23 +271,25 @@ func TestLargeResponseAuditTruncation(t *testing.T) {
 	req.URL.Scheme = "http"
 
 	resp := handler.processRequest(req, "req_stream_audit", time.Now(), context.Background())
-	io.Copy(io.Discard, resp.Body)
+	received, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading response: %v", err)
+	}
 	resp.Body.Close()
+	if len(received) != len(data) {
+		t.Fatalf("received %d bytes, want %d", len(received), len(data))
+	}
 
 	entries := readAuditEntries(t, auditFile)
 	if len(entries) == 0 {
 		t.Fatal("no audit entries written")
 	}
 	e := entries[len(entries)-1]
-	if !strings.HasSuffix(e.ResponseBody, "[response body truncated for logging]") {
-		got := e.ResponseBody
-		if len(got) > 64 {
-			got = got[len(got)-64:]
-		}
-		t.Fatalf("expected truncated ResponseBody marker, got suffix %q", got)
+	if e.ResponseStatus != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, e.ResponseStatus)
 	}
-	if len(e.ResponseBody) <= maxBufferedBodySize {
-		t.Errorf("expected capped ResponseBody plus marker, got %d bytes", len(e.ResponseBody))
+	if e.ResponseBody != "" {
+		t.Fatalf("expected early file audit entry to omit streamed response body, got %q", e.ResponseBody)
 	}
 }
 

--- a/internal/proxy/streaming_test.go
+++ b/internal/proxy/streaming_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -254,9 +255,8 @@ func TestChunkedResponseIsStreamedBeforeCompletion(t *testing.T) {
 	}
 }
 
-// TestLargeResponseAuditTruncation verifies that the audit log entry written to
-// file does not contain the response body (sensitive payload is stripped from
-// file/stdout output).
+// TestLargeResponseAuditTruncation verifies that the file audit output preserves
+// the capped response body with a truncation marker.
 func TestLargeResponseAuditTruncation(t *testing.T) {
 	data := makeLargeBody(largeBodySize)
 	auditFile := filepath.Join(t.TempDir(), "audit.jsonl")
@@ -280,15 +280,20 @@ func TestLargeResponseAuditTruncation(t *testing.T) {
 		t.Fatal("no audit entries written")
 	}
 	e := entries[len(entries)-1]
-	// File/stdout audit output strips response bodies to avoid logging sensitive data.
-	if e.ResponseBody != "" {
-		t.Errorf("expected empty ResponseBody in file audit output, got %d bytes", len(e.ResponseBody))
+	if !strings.HasSuffix(e.ResponseBody, "[response body truncated for logging]") {
+		got := e.ResponseBody
+		if len(got) > 64 {
+			got = got[len(got)-64:]
+		}
+		t.Fatalf("expected truncated ResponseBody marker, got suffix %q", got)
+	}
+	if len(e.ResponseBody) <= maxBufferedBodySize {
+		t.Errorf("expected capped ResponseBody plus marker, got %d bytes", len(e.ResponseBody))
 	}
 }
 
 // TestSmallResponseFullyBuffered verifies that responses under maxBufferedBodySize
-// are fully delivered to the client. The file audit output strips the response body
-// to avoid logging sensitive payload data.
+// are fully delivered to the client and preserved in file audit output.
 func TestSmallResponseFullyBuffered(t *testing.T) {
 	data := []byte(`{"message":"small response ok"}`)
 	auditFile := filepath.Join(t.TempDir(), "audit.jsonl")
@@ -323,9 +328,8 @@ func TestSmallResponseFullyBuffered(t *testing.T) {
 		t.Fatal("no audit entries written")
 	}
 	e := entries[len(entries)-1]
-	// File/stdout audit output strips response bodies to avoid logging sensitive data.
-	if e.ResponseBody != "" {
-		t.Errorf("expected empty ResponseBody in file audit output, got %q", e.ResponseBody)
+	if e.ResponseBody != string(data) {
+		t.Errorf("expected ResponseBody %q in file audit output, got %q", data, e.ResponseBody)
 	}
 }
 


### PR DESCRIPTION
## Summary
- broadcast a lightweight audit entry copy over realtime notifications
- clear request and response bodies from live audit events while preserving the original audit entry
- add a regression test covering sanitized broadcasts and caller entry immutability

Fixes #9

## Testing
- go test ./internal/audit ./internal/notifications ./pkg/types
- go test -race ./internal/audit ./internal/notifications ./pkg/types
- env PATH=/Users/nathanmetzger/go/bin:$PATH make lint
- env PATH=/Users/nathanmetzger/go/bin:$PATH make test (lint passed; test phase blocked locally by rootless Docker not found from Testcontainers)