### PR TITLE
fix: normalize nil static rule methods to prevent policy editor crash

### DIFF
--- a/internal/builder/agent.go
+++ b/internal/builder/agent.go
@@ -326,6 +326,10 @@ func (a *PolicyAgent) toolUpdatePolicy(input json.RawMessage, state *agentState)
 	if err := json.Unmarshal(input, &params); err != nil {
 		return "", fmt.Errorf("invalid update_policy input: %w", err)
 	}
+	if params.StaticRules == nil {
+		params.StaticRules = []types.StaticRule{}
+	}
+	types.NormalizeStaticRules(params.StaticRules)
 	state.currentPrompt = params.PolicyPrompt
 	state.currentRules = params.StaticRules
 	state.policyUpdated = true

--- a/internal/builder/agent_test.go
+++ b/internal/builder/agent_test.go
@@ -647,6 +647,38 @@ func TestPolicyAgent_ToolCallHistoryReplayedToModel(t *testing.T) {
 }
 
 
+func TestPolicyAgent_UpdatePolicy_NilMethodsNormalized(t *testing.T) {
+	callN := 0
+	thinking := &llm.TestAdapter{Fn: func(req llm.Request) (llm.Response, error) {
+		callN++
+		if callN == 1 {
+			// LLM omits methods field entirely — produces null after unmarshal
+			input := json.RawMessage(`{"policy_prompt":"p","static_rules":[{"url_pattern":"https://example.com/","match_type":"prefix","action":"allow"}]}`)
+			return llm.Response{
+				StopReason: "tool_use",
+				ToolCalls:  []llm.ToolCall{{ID: "c1", Name: "update_policy", Input: input}},
+			}, nil
+		}
+		return llm.Response{Text: "Done.", StopReason: "end_turn"}, nil
+	}}
+
+	agent := NewPolicyAgent(&stubReader{}, nil, thinking)
+	result, err := agent.Run(context.Background(), "", "", nil, nil, nil, "create policy", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.StaticRules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(result.StaticRules))
+	}
+	if result.StaticRules[0].Methods == nil {
+		t.Error("Methods should be normalized to empty slice, not nil")
+	}
+	b, _ := json.Marshal(result.StaticRules[0].Methods)
+	if string(b) != "[]" {
+		t.Errorf("Methods should serialize as [], got %s", string(b))
+	}
+}
+
 func TestPathPrefixFromPattern(t *testing.T) {
 	cases := []struct{ pattern, want string }{
 		{"/v1/applications/{id}", "/v1/applications/"},

--- a/internal/llmpolicy/pg_store.go
+++ b/internal/llmpolicy/pg_store.go
@@ -62,6 +62,7 @@ func scanPolicy(row interface {
 	if forkedFrom != nil {
 		p.ForkedFrom = *forkedFrom
 	}
+	types.NormalizeStaticRules(p.StaticRules)
 	return &p, nil
 }
 
@@ -158,6 +159,7 @@ func (s *PGStore) Create(name, prompt, provider, model, forkedFrom, status strin
 	if staticRules == nil {
 		staticRules = []types.StaticRule{}
 	}
+	types.NormalizeStaticRules(staticRules)
 	var forkedFromPtr *string
 	if forkedFrom != "" {
 		forkedFromPtr = &forkedFrom
@@ -196,6 +198,7 @@ func (s *PGStore) UpdateDraft(id, name, prompt, provider, model string, staticRu
 	if staticRules == nil {
 		staticRules = []types.StaticRule{}
 	}
+	types.NormalizeStaticRules(staticRules)
 	ctx := context.Background()
 
 	tag, err := s.pool.Exec(ctx, `

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -118,6 +118,16 @@ type StaticRule struct {
 	Action     string   `json:"action"`      // "allow" (default) | "deny"
 }
 
+// NormalizeStaticRules replaces nil Methods slices with empty slices
+// so JSON serialization produces [] instead of null.
+func NormalizeStaticRules(rules []StaticRule) {
+	for i := range rules {
+		if rules[i].Methods == nil {
+			rules[i].Methods = []string{}
+		}
+	}
+}
+
 // ToolCallRecord records a tool invocation made by the assistant.
 type ToolCallRecord struct {
 	ID    string          `json:"id"`

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeStaticRules_NilMethodsBecomesEmptySlice(t *testing.T) {
+	rules := []StaticRule{
+		{Methods: nil, URLPattern: "https://example.com/", MatchType: "prefix", Action: "allow"},
+		{Methods: []string{"GET"}, URLPattern: "https://api.example.com/", MatchType: "prefix", Action: "allow"},
+	}
+	NormalizeStaticRules(rules)
+
+	if rules[0].Methods == nil {
+		t.Error("expected Methods to be non-nil after normalization")
+	}
+	if len(rules[0].Methods) != 0 {
+		t.Errorf("expected empty Methods, got %v", rules[0].Methods)
+	}
+	if len(rules[1].Methods) != 1 || rules[1].Methods[0] != "GET" {
+		t.Errorf("expected Methods=[GET], got %v", rules[1].Methods)
+	}
+}
+
+func TestNormalizeStaticRules_EmptyInput(t *testing.T) {
+	NormalizeStaticRules(nil)
+	NormalizeStaticRules([]StaticRule{})
+}
+
+func TestNormalizeStaticRules_JSONSerializesAsEmptyArray(t *testing.T) {
+	rules := []StaticRule{
+		{Methods: nil, URLPattern: "https://example.com/"},
+	}
+	NormalizeStaticRules(rules)
+
+	b, err := json.Marshal(rules[0].Methods)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if string(b) != "[]" {
+		t.Errorf("expected JSON [], got %s", string(b))
+	}
+}

--- a/web/src/components/PolicyDetail.tsx
+++ b/web/src/components/PolicyDetail.tsx
@@ -42,7 +42,7 @@ function StaticRulesEditor({ rules, onChange, readOnly }: {
           return (
             <div key={i} className={`flex items-center gap-2 text-xs font-mono rounded px-3 py-1.5 border ${isDeny ? 'bg-red-50 border-red-200' : 'bg-gray-50 border-gray-100'}`}>
               <span className={`font-semibold px-1.5 py-0.5 rounded text-xs ${isDeny ? 'bg-red-100 text-red-700' : 'bg-blue-100 text-blue-700'}`}>{isDeny ? 'deny' : 'allow'}</span>
-              <span className="text-blue-600 font-semibold">{rule.methods.length > 0 ? rule.methods.join(' ') : '*'}</span>
+              <span className="text-blue-600 font-semibold">{rule.methods && rule.methods.length > 0 ? rule.methods.join(' ') : '*'}</span>
               <span className="text-gray-700 flex-1 truncate">{rule.url_pattern}</span>
               <span className="text-gray-400">{rule.match_type ?? 'prefix'}</span>
             </div>
@@ -69,7 +69,7 @@ function StaticRulesEditor({ rules, onChange, readOnly }: {
             </select>
             <input
               className="border border-gray-300 rounded-lg px-2 py-1.5 text-xs w-24 focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
-              value={rule.methods.join(',')}
+              value={(rule.methods ?? []).join(',')}
               onChange={(e) => updateRule(i, { methods: e.target.value ? e.target.value.split(',').map(m => m.trim().toUpperCase()).filter(Boolean) : [] })}
               placeholder="GET,POST"
             />
@@ -164,7 +164,9 @@ function DraftEditor({ policy, metadata, onSaved, onPublished, onDeleted, initia
   const [prompt, setPrompt] = useState(policy.prompt)
   const [provider, setProvider] = useState(policy.provider)
   const [model, setModel] = useState(policy.model)
-  const [rules, setRules] = useState<StaticRule[]>(policy.static_rules ?? [])
+  const [rules, setRules] = useState<StaticRule[]>(
+    (policy.static_rules ?? []).map(r => ({ ...r, methods: r.methods ?? [] }))
+  )
   const [saving, setSaving] = useState(false)
   const [saveErr, setSaveErr] = useState<string | null>(null)
   const [publishing, setPublishing] = useState(false)
@@ -289,7 +291,7 @@ function DraftEditor({ policy, metadata, onSaved, onPublished, onDeleted, initia
       case 'policy_updated': {
         const r = d as { policy_prompt: string; static_rules: StaticRule[] }
         setPrompt(r.policy_prompt)
-        setRules(r.static_rules ?? [])
+        setRules((r.static_rules ?? []).map(rule => ({ ...rule, methods: rule.methods ?? [] })))
         break
       }
       case 'name_updated':

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -32,7 +32,7 @@ export interface SSEEvent {
 // ---- LLM Policy types ----
 
 export interface StaticRule {
-  methods: string[]       // empty = all methods
+  methods: string[] | null  // empty/null = all methods
   url_pattern: string
   match_type?: 'prefix' | 'exact' | 'glob'  // default "prefix"
   action?: 'allow' | 'deny'                  // default "allow"


### PR DESCRIPTION
When a StaticRule had a nil Methods slice json.Marshal produced "methods": null. The frontend accessed .length and .join() on this null value, crashing the policy editor with "Cannot read properties of null".

Backend: add NormalizeStaticRules() that replaces nil Methods with empty slices. Call it on all read paths (scanPolicy), write paths (Create, UpdateDraft), and after unmarshaling LLM tool output (toolUpdatePolicy).

Frontend: update the StaticRule type to allow null, add null guards in the read-only view, edit input, state initialization, and SSE event handler so the UI is resilient to any remaining bad data.

Closes #8