### PR TITLE
fix: strip scheme symmetrically in glob static-rule matching

### DIFF
--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -419,12 +419,19 @@ func staticURLMatches(urlStr, pattern, matchType string) bool {
 	case "exact":
 		return decoded == normalizedPattern
 	case "glob":
-		// Strip scheme (e.g. "https://") so patterns like "*.example.com/*" work.
+		// Strip scheme (e.g. "https://") from both the URL and the pattern so
+		// that patterns authored with or without a scheme behave identically.
+		// The URL string reconstructed by the proxy always carries a scheme;
+		// user-authored patterns may or may not.
 		stripped := decoded
 		if i := strings.Index(decoded, "://"); i >= 0 {
 			stripped = decoded[i+3:]
 		}
-		re, err := globToRegexp(normalizedPattern)
+		patternForGlob := normalizedPattern
+		if i := strings.Index(normalizedPattern, "://"); i >= 0 {
+			patternForGlob = normalizedPattern[i+3:]
+		}
+		re, err := globToRegexp(patternForGlob)
 		if err != nil {
 			return false
 		}

--- a/internal/approval/manager_llm_test.go
+++ b/internal/approval/manager_llm_test.go
@@ -476,6 +476,9 @@ func TestStaticURLMatches(t *testing.T) {
 		{"https://api.example.com/repos/123/extra/comments", "api.example.com/repos/*/comments", "glob", true},  // * crosses /
 		{"https://api.example.com/repos/comments",           "api.example.com/repos/*/comments", "glob", false}, // empty segment — * requires at least one char
 		{"https://api.example.com/repos/123/comments/extra", "api.example.com/repos/*/comments", "glob", false}, // trailing extra
+		// glob with scheme in the pattern — scheme stripped symmetrically so it still matches
+		{"https://api.github.com/repos/owner/repo/readme", "https://api.github.com/repos/*/*/readme", "glob", true},
+		{"https://api.github.com/repos/owner/repo/readme", "http://api.github.com/repos/*/*/readme", "glob", true}, // scheme in pattern is ignored
 		// default port normalisation — :443 for https, :80 for http
 		{"https://brex.okta.com:443/.well-known/openid-configuration", "https://brex.okta.com/", "prefix", true},
 		{"https://brex.okta.com/.well-known/openid-configuration", "https://brex.okta.com:443/", "prefix", true},


### PR DESCRIPTION
## Summary

- Static rules authored with a scheme (e.g. `https://api.github.com/repos/*/*/readme`) and `match_type=glob` silently never matched because the URL was scheme-stripped before regex compare but the pattern was not. Requests fell through to the LLM judge instead of short-circuiting.
- Strip the scheme from both sides in the `glob` branch of `staticURLMatches` so scheme-prefixed and scheme-less glob patterns behave identically.
- Added two regression cases to `TestStaticURLMatches` covering scheme-prefixed glob patterns.

Known tradeoff: glob patterns cannot pin scheme (e.g. `http://` vs `https://`). This matches the existing convention of scheme-less glob patterns used throughout the suite; scheme pinning is still available via `prefix` / `exact`.

## Test plan

- [x] `go test ./internal/approval/...` passes (existing cases unaffected, new cases pass)
- [ ] In a running instance, verify a policy with `allow GET https://api.github.com/repos/*/*/readme` (glob) short-circuits at the static rule and records `approved_by = "llm-static-rule"`
- [ ] Re-run an eval replay against a previously-denied request — expect `DENY` to flip to `ALLOW`

🤖 Generated with [Claude Code](https://claude.com/claude-code)