### PR TITLE
feat(auth): manager-bot assignment with scoped user list

### DIFF
--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -283,12 +283,12 @@ func (a *API) handleMe(w http.ResponseWriter, r *http.Request) {
 // For admins, returns all bot (role "user") users since admins manage everything.
 // GET /admin/me/bots
 func (a *API) handleMeBots(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
 	callerID, callerRole, ok := a.requireRole(w, r, "manager")
 	if !ok {
+		return
+	}
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	if a.userStore == nil {
@@ -606,6 +606,11 @@ func (a *API) handleUserAction(w http.ResponseWriter, r *http.Request) {
 // POST /admin/users/{id}/managers — assign manager (admin only)
 // DELETE /admin/users/{id}/managers/{manager_id} — unassign (admin only)
 func (a *API) handleUserManagers(w http.ResponseWriter, r *http.Request, botID string, subPath string) {
+	callerID, callerRole, ok := a.requireRole(w, r, "manager")
+	if !ok {
+		return
+	}
+
 	// subPath is "/managers" or "/managers/{manager_id}"
 	managerSuffix := strings.TrimPrefix(subPath, "/managers")
 
@@ -613,10 +618,6 @@ func (a *API) handleUserManagers(w http.ResponseWriter, r *http.Request, botID s
 	case managerSuffix == "" || managerSuffix == "/":
 		switch r.Method {
 		case http.MethodGet:
-			callerID, callerRole, ok := a.requireRole(w, r, "manager")
-			if !ok {
-				return
-			}
 			if callerRole != "admin" {
 				isMgr, err := a.userStore.IsManagerOf(callerID, botID)
 				if err != nil || !isMgr {
@@ -631,7 +632,8 @@ func (a *API) handleUserManagers(w http.ResponseWriter, r *http.Request, botID s
 			}
 			respondJSON(w, http.StatusOK, managers)
 		case http.MethodPost:
-			if _, ok := a.requireAdmin(w, r); !ok {
+			if callerRole != "admin" {
+				http.Error(w, "Forbidden", http.StatusForbidden)
 				return
 			}
 			limitBody(w, r, maxBodySize)
@@ -680,7 +682,8 @@ func (a *API) handleUserManagers(w http.ResponseWriter, r *http.Request, botID s
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		if _, ok := a.requireAdmin(w, r); !ok {
+		if callerRole != "admin" {
+			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}
 		managerID, err := url.PathUnescape(managerSuffix[1:])

--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -280,18 +280,34 @@ func (a *API) handleMe(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleMeBots returns the bots managed by the authenticated user.
+// For admins, returns all bot (role "user") users since admins manage everything.
 // GET /admin/me/bots
 func (a *API) handleMeBots(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	callerID, _, ok := a.requireRole(w, r, "manager")
+	callerID, callerRole, ok := a.requireRole(w, r, "manager")
 	if !ok {
 		return
 	}
 	if a.userStore == nil {
 		http.Error(w, "User store not available", http.StatusServiceUnavailable)
+		return
+	}
+	if callerRole == "admin" {
+		users, err := a.userStore.ListUsers()
+		if err != nil {
+			respondError(w, http.StatusInternalServerError, "failed to list users", err)
+			return
+		}
+		bots := []UserSummary{}
+		for _, u := range users {
+			if u.Role == "user" {
+				bots = append(bots, u)
+			}
+		}
+		respondJSON(w, http.StatusOK, bots)
 		return
 	}
 	bots, err := a.userStore.ListManagedBots(callerID)
@@ -407,8 +423,8 @@ func (a *API) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleUsers handles GET /admin/users (list) and POST /admin/users (create).
-// GET is accessible to managers (filtered to assigned bots) and admins (full list).
-// POST is admin-only.
+// GET is accessible to managers (returns only assigned bots) and admins (full list).
+// POST is accessible to managers (creates bot users auto-assigned to caller) and admins (any role).
 func (a *API) handleUsers(w http.ResponseWriter, r *http.Request) {
 	if a.userStore == nil {
 		http.Error(w, "User store not available", http.StatusServiceUnavailable)
@@ -420,32 +436,21 @@ func (a *API) handleUsers(w http.ResponseWriter, r *http.Request) {
 		if !ok {
 			return
 		}
-		users, err := a.userStore.ListUsers()
+		var users []UserSummary
+		var err error
+		if callerRole == "admin" {
+			users, err = a.userStore.ListUsers()
+		} else {
+			users, err = a.userStore.ListUsersForManager(callerID)
+		}
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, "failed to list users", err)
 			return
 		}
-		if callerRole != "admin" {
-			assignments, err := a.userStore.ListManagedBots(callerID)
-			if err != nil {
-				respondError(w, http.StatusInternalServerError, "failed to list managed bots", err)
-				return
-			}
-			allowed := make(map[string]bool, len(assignments))
-			for _, asn := range assignments {
-				allowed[asn.BotID] = true
-			}
-			filtered := make([]UserSummary, 0, len(assignments))
-			for _, u := range users {
-				if allowed[u.ID] {
-					filtered = append(filtered, u)
-				}
-			}
-			users = filtered
-		}
 		respondJSON(w, http.StatusOK, users)
 	case http.MethodPost:
-		if _, ok := a.requireAdmin(w, r); !ok {
+		callerID, callerRole, ok := a.requireRole(w, r, "manager")
+		if !ok {
 			return
 		}
 		limitBody(w, r, maxBodySize)
@@ -461,10 +466,23 @@ func (a *API) handleUsers(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "invalid role: must be admin, manager, or user", http.StatusBadRequest)
 			return
 		}
+		// Managers can only create bot users (role "user").
+		if callerRole != "admin" {
+			userRole := "user"
+			if req.Role != nil && *req.Role != "user" {
+				http.Error(w, "managers can only create bot users", http.StatusForbidden)
+				return
+			}
+			req.Role = &userRole
+		}
 		user, err := a.userStore.CreateUser(req)
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, "failed to create user", err)
 			return
+		}
+		// Auto-assign the manager to the newly created bot.
+		if callerRole != "admin" {
+			_ = a.userStore.AssignManager(user.ID, callerID)
 		}
 		respondJSON(w, http.StatusCreated, user)
 	default:

--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -632,8 +632,7 @@ func (a *API) handleUserManagers(w http.ResponseWriter, r *http.Request, botID s
 			}
 			respondJSON(w, http.StatusOK, managers)
 		case http.MethodPost:
-			callerID, callerRole, ok := a.requireRole(w, r, "manager")
-			if !ok {
+			if _, ok := a.requireAdmin(w, r); !ok {
 				return
 			}
 			limitBody(w, r, maxBodySize)
@@ -645,11 +644,6 @@ func (a *API) handleUserManagers(w http.ResponseWriter, r *http.Request, botID s
 			}
 			if body.ManagerID == "" {
 				http.Error(w, "manager_id is required", http.StatusBadRequest)
-				return
-			}
-			// Managers can only assign themselves; admins can assign anyone.
-			if callerRole != "admin" && body.ManagerID != callerID {
-				http.Error(w, "managers can only assign themselves", http.StatusForbidden)
 				return
 			}
 			// Validate bot exists and has "user" role (only bots can have managers).

--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -295,25 +295,26 @@ func (a *API) handleMeBots(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "User store not available", http.StatusServiceUnavailable)
 		return
 	}
+	var bots []UserSummary
+	var err error
 	if callerRole == "admin" {
-		users, err := a.userStore.ListUsers()
-		if err != nil {
-			respondError(w, http.StatusInternalServerError, "failed to list users", err)
+		all, listErr := a.userStore.ListUsers()
+		if listErr != nil {
+			respondError(w, http.StatusInternalServerError, "failed to list users", listErr)
 			return
 		}
-		bots := []UserSummary{}
-		for _, u := range users {
+		bots = make([]UserSummary, 0, len(all))
+		for _, u := range all {
 			if u.Role == "user" {
 				bots = append(bots, u)
 			}
 		}
-		respondJSON(w, http.StatusOK, bots)
-		return
-	}
-	bots, err := a.userStore.ListManagedBots(callerID)
-	if err != nil {
-		respondError(w, http.StatusInternalServerError, "failed to list managed bots", err)
-		return
+	} else {
+		bots, err = a.userStore.ListUsersForManager(callerID)
+		if err != nil {
+			respondError(w, http.StatusInternalServerError, "failed to list managed bots", err)
+			return
+		}
 	}
 	respondJSON(w, http.StatusOK, bots)
 }
@@ -482,7 +483,12 @@ func (a *API) handleUsers(w http.ResponseWriter, r *http.Request) {
 		}
 		// Auto-assign the manager to the newly created bot.
 		if callerRole != "admin" {
-			_ = a.userStore.AssignManager(user.ID, callerID)
+			if assignErr := a.userStore.AssignManager(user.ID, callerID); assignErr != nil {
+				// Roll back: delete the orphan user so it doesn't become invisible.
+				_ = a.userStore.DeleteUser(user.ID)
+				respondError(w, http.StatusInternalServerError, "failed to assign manager to new bot", assignErr)
+				return
+			}
 		}
 		respondJSON(w, http.StatusCreated, user)
 	default:
@@ -627,9 +633,14 @@ func (a *API) handleUserManagers(w http.ResponseWriter, r *http.Request, botID s
 				http.Error(w, "manager_id is required", http.StatusBadRequest)
 				return
 			}
-			// Validate bot exists.
-			if _, err := a.userStore.GetUser(botID); err != nil {
+			// Validate bot exists and has "user" role (only bots can have managers).
+			bot, err := a.userStore.GetUser(botID)
+			if err != nil {
 				http.Error(w, "bot user not found", http.StatusNotFound)
+				return
+			}
+			if bot.Role != "user" {
+				http.Error(w, "managers can only be assigned to bot users", http.StatusBadRequest)
 				return
 			}
 			// Validate manager exists and has an appropriate role.

--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -431,12 +431,12 @@ func (a *API) handleUsers(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "User store not available", http.StatusServiceUnavailable)
 		return
 	}
+	callerID, callerRole, ok := a.requireRole(w, r, "manager")
+	if !ok {
+		return
+	}
 	switch r.Method {
 	case http.MethodGet:
-		callerID, callerRole, ok := a.requireRole(w, r, "manager")
-		if !ok {
-			return
-		}
 		var users []UserSummary
 		var err error
 		if callerRole == "admin" {
@@ -450,10 +450,6 @@ func (a *API) handleUsers(w http.ResponseWriter, r *http.Request) {
 		}
 		respondJSON(w, http.StatusOK, users)
 	case http.MethodPost:
-		callerID, callerRole, ok := a.requireRole(w, r, "manager")
-		if !ok {
-			return
-		}
 		limitBody(w, r, maxBodySize)
 		var req CreateUserRequest
 		if !decodeBody(w, r, &req) {
@@ -538,13 +534,14 @@ func (a *API) handleUserAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Auth: at minimum require manager role; PUT/DELETE further require admin.
+	callerID, callerRole, ok := a.requireRole(w, r, "manager")
+	if !ok {
+		return
+	}
+
 	switch r.Method {
 	case http.MethodGet:
-		// GET allows managers to view bots they're assigned to.
-		callerID, callerRole, ok := a.requireRole(w, r, "manager")
-		if !ok {
-			return
-		}
 		if callerRole != "admin" {
 			isMgr, mgrErr := a.userStore.IsManagerOf(callerID, email)
 			if mgrErr != nil || !isMgr {
@@ -559,7 +556,8 @@ func (a *API) handleUserAction(w http.ResponseWriter, r *http.Request) {
 		}
 		respondJSON(w, http.StatusOK, user)
 	case http.MethodPut:
-		if _, ok := a.requireAdmin(w, r); !ok {
+		if callerRole != "admin" {
+			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}
 		limitBody(w, r, maxBodySize)
@@ -589,7 +587,8 @@ func (a *API) handleUserAction(w http.ResponseWriter, r *http.Request) {
 		}
 		respondJSON(w, http.StatusOK, user)
 	case http.MethodDelete:
-		if _, ok := a.requireAdmin(w, r); !ok {
+		if callerRole != "admin" {
+			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}
 		if err := a.userStore.DeleteUser(email); err != nil {

--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -538,13 +538,20 @@ func (a *API) handleUserAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// CRUD on the user itself — admin only.
-	if _, ok := a.requireAdmin(w, r); !ok {
-		return
-	}
-
 	switch r.Method {
 	case http.MethodGet:
+		// GET allows managers to view bots they're assigned to.
+		callerID, callerRole, ok := a.requireRole(w, r, "manager")
+		if !ok {
+			return
+		}
+		if callerRole != "admin" {
+			isMgr, mgrErr := a.userStore.IsManagerOf(callerID, email)
+			if mgrErr != nil || !isMgr {
+				http.Error(w, "Forbidden", http.StatusForbidden)
+				return
+			}
+		}
 		user, err := a.userStore.GetUser(email)
 		if err != nil {
 			respondError(w, http.StatusNotFound, "user not found", err)
@@ -552,6 +559,9 @@ func (a *API) handleUserAction(w http.ResponseWriter, r *http.Request) {
 		}
 		respondJSON(w, http.StatusOK, user)
 	case http.MethodPut:
+		if _, ok := a.requireAdmin(w, r); !ok {
+			return
+		}
 		limitBody(w, r, maxBodySize)
 		var req UpdateUserRequest
 		if !decodeBody(w, r, &req) {
@@ -579,6 +589,9 @@ func (a *API) handleUserAction(w http.ResponseWriter, r *http.Request) {
 		}
 		respondJSON(w, http.StatusOK, user)
 	case http.MethodDelete:
+		if _, ok := a.requireAdmin(w, r); !ok {
+			return
+		}
 		if err := a.userStore.DeleteUser(email); err != nil {
 			respondError(w, http.StatusNotFound, "user not found", err)
 			return

--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -432,8 +432,8 @@ func (a *API) handleUsers(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			allowed := make(map[string]bool, len(assignments))
-			for _, a := range assignments {
-				allowed[a.BotID] = true
+			for _, asn := range assignments {
+				allowed[asn.BotID] = true
 			}
 			filtered := make([]UserSummary, 0, len(assignments))
 			for _, u := range users {
@@ -607,6 +607,21 @@ func (a *API) handleUserManagers(w http.ResponseWriter, r *http.Request, botID s
 			}
 			if body.ManagerID == "" {
 				http.Error(w, "manager_id is required", http.StatusBadRequest)
+				return
+			}
+			// Validate bot exists.
+			if _, err := a.userStore.GetUser(botID); err != nil {
+				http.Error(w, "bot user not found", http.StatusNotFound)
+				return
+			}
+			// Validate manager exists and has an appropriate role.
+			mgr, err := a.userStore.GetUser(body.ManagerID)
+			if err != nil {
+				http.Error(w, "manager user not found", http.StatusBadRequest)
+				return
+			}
+			if mgr.Role != "manager" && mgr.Role != "admin" {
+				http.Error(w, "user must have manager or admin role", http.StatusBadRequest)
 				return
 			}
 			if err := a.userStore.AssignManager(botID, body.ManagerID); err != nil {

--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -178,6 +178,7 @@ func (a *API) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/admin/events", a.handleSSE)
 
 	// Identity endpoint
+	mux.HandleFunc("/admin/me/bots", a.handleMeBots)
 	mux.HandleFunc("/admin/me", a.handleMe)
 
 	// Health endpoint (shows pending count)
@@ -276,6 +277,29 @@ func (a *API) handleMe(w http.ResponseWriter, r *http.Request) {
 		"role":     role,
 		"is_admin": role == "admin",
 	})
+}
+
+// handleMeBots returns the bots managed by the authenticated user.
+// GET /admin/me/bots
+func (a *API) handleMeBots(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	callerID, _, ok := a.requireRole(w, r, "manager")
+	if !ok {
+		return
+	}
+	if a.userStore == nil {
+		http.Error(w, "User store not available", http.StatusServiceUnavailable)
+		return
+	}
+	bots, err := a.userStore.ListManagedBots(callerID)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "failed to list managed bots", err)
+		return
+	}
+	respondJSON(w, http.StatusOK, bots)
 }
 
 // handleAuditLog returns audit entries with optional filters
@@ -383,23 +407,47 @@ func (a *API) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleUsers handles GET /admin/users (list) and POST /admin/users (create).
+// GET is accessible to managers (filtered to assigned bots) and admins (full list).
+// POST is admin-only.
 func (a *API) handleUsers(w http.ResponseWriter, r *http.Request) {
-	if _, ok := a.requireAdmin(w, r); !ok {
-		return
-	}
 	if a.userStore == nil {
 		http.Error(w, "User store not available", http.StatusServiceUnavailable)
 		return
 	}
 	switch r.Method {
 	case http.MethodGet:
+		callerID, callerRole, ok := a.requireRole(w, r, "manager")
+		if !ok {
+			return
+		}
 		users, err := a.userStore.ListUsers()
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, "failed to list users", err)
 			return
 		}
+		if callerRole != "admin" {
+			assignments, err := a.userStore.ListManagedBots(callerID)
+			if err != nil {
+				respondError(w, http.StatusInternalServerError, "failed to list managed bots", err)
+				return
+			}
+			allowed := make(map[string]bool, len(assignments))
+			for _, a := range assignments {
+				allowed[a.BotID] = true
+			}
+			filtered := make([]UserSummary, 0, len(assignments))
+			for _, u := range users {
+				if allowed[u.ID] {
+					filtered = append(filtered, u)
+				}
+			}
+			users = filtered
+		}
 		respondJSON(w, http.StatusOK, users)
 	case http.MethodPost:
+		if _, ok := a.requireAdmin(w, r); !ok {
+			return
+		}
 		limitBody(w, r, maxBodySize)
 		var req CreateUserRequest
 		if !decodeBody(w, r, &req) {
@@ -424,18 +472,14 @@ func (a *API) handleUsers(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handleUserAction routes /admin/users/{email}.
+// handleUserAction routes /admin/users/{email} and /admin/users/{email}/managers[/{manager_id}].
 func (a *API) handleUserAction(w http.ResponseWriter, r *http.Request) {
-	if _, ok := a.requireAdmin(w, r); !ok {
-		return
-	}
 	if a.userStore == nil {
 		http.Error(w, "User store not available", http.StatusServiceUnavailable)
 		return
 	}
 
 	const prefix = "/admin/users/"
-	// Use RawPath when available so we unescape exactly once.
 	rawPath := r.URL.RawPath
 	if rawPath == "" {
 		rawPath = r.URL.Path
@@ -446,9 +490,32 @@ func (a *API) handleUserAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	email, err := url.PathUnescape(remaining)
+	// Split remaining into user ID and optional sub-resource.
+	// e.g. "bob%40x.com/managers/alice%40x.com" → id="bob@x.com", sub="/managers/alice@x.com"
+	idPart := remaining
+	subPath := ""
+	if idx := strings.Index(remaining, "/"); idx > 0 {
+		idPart = remaining[:idx]
+		subPath = remaining[idx:]
+	}
+
+	email, err := url.PathUnescape(idPart)
 	if err != nil || email == "" {
 		http.Error(w, "Invalid user ID", http.StatusBadRequest)
+		return
+	}
+
+	if strings.HasPrefix(subPath, "/managers") {
+		a.handleUserManagers(w, r, email, subPath)
+		return
+	}
+	if subPath != "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	// CRUD on the user itself — admin only.
+	if _, ok := a.requireAdmin(w, r); !ok {
 		return
 	}
 
@@ -495,6 +562,84 @@ func (a *API) handleUserAction(w http.ResponseWriter, r *http.Request) {
 		respondJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 	default:
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleUserManagers handles /admin/users/{id}/managers and /admin/users/{id}/managers/{manager_id}.
+// GET /admin/users/{id}/managers — list managers (admin or manager-of)
+// POST /admin/users/{id}/managers — assign manager (admin only)
+// DELETE /admin/users/{id}/managers/{manager_id} — unassign (admin only)
+func (a *API) handleUserManagers(w http.ResponseWriter, r *http.Request, botID string, subPath string) {
+	// subPath is "/managers" or "/managers/{manager_id}"
+	managerSuffix := strings.TrimPrefix(subPath, "/managers")
+
+	switch {
+	case managerSuffix == "" || managerSuffix == "/":
+		switch r.Method {
+		case http.MethodGet:
+			callerID, callerRole, ok := a.requireRole(w, r, "manager")
+			if !ok {
+				return
+			}
+			if callerRole != "admin" {
+				isMgr, err := a.userStore.IsManagerOf(callerID, botID)
+				if err != nil || !isMgr {
+					http.Error(w, "Forbidden", http.StatusForbidden)
+					return
+				}
+			}
+			managers, err := a.userStore.ListManagers(botID)
+			if err != nil {
+				respondError(w, http.StatusInternalServerError, "failed to list managers", err)
+				return
+			}
+			respondJSON(w, http.StatusOK, managers)
+		case http.MethodPost:
+			if _, ok := a.requireAdmin(w, r); !ok {
+				return
+			}
+			limitBody(w, r, maxBodySize)
+			var body struct {
+				ManagerID string `json:"manager_id"`
+			}
+			if !decodeBody(w, r, &body) {
+				return
+			}
+			if body.ManagerID == "" {
+				http.Error(w, "manager_id is required", http.StatusBadRequest)
+				return
+			}
+			if err := a.userStore.AssignManager(botID, body.ManagerID); err != nil {
+				respondError(w, http.StatusInternalServerError, "failed to assign manager", err)
+				return
+			}
+			respondJSON(w, http.StatusCreated, map[string]string{"status": "assigned"})
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+
+	case strings.HasPrefix(managerSuffix, "/"):
+		// DELETE /admin/users/{id}/managers/{manager_id}
+		if r.Method != http.MethodDelete {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if _, ok := a.requireAdmin(w, r); !ok {
+			return
+		}
+		managerID, err := url.PathUnescape(managerSuffix[1:])
+		if err != nil || managerID == "" {
+			http.Error(w, "Invalid manager ID", http.StatusBadRequest)
+			return
+		}
+		if err := a.userStore.UnassignManager(botID, managerID); err != nil {
+			respondError(w, http.StatusNotFound, "assignment not found", err)
+			return
+		}
+		respondJSON(w, http.StatusOK, map[string]string{"status": "unassigned"})
+
+	default:
+		http.NotFound(w, r)
 	}
 }
 

--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -632,7 +632,8 @@ func (a *API) handleUserManagers(w http.ResponseWriter, r *http.Request, botID s
 			}
 			respondJSON(w, http.StatusOK, managers)
 		case http.MethodPost:
-			if _, ok := a.requireAdmin(w, r); !ok {
+			callerID, callerRole, ok := a.requireRole(w, r, "manager")
+			if !ok {
 				return
 			}
 			limitBody(w, r, maxBodySize)
@@ -644,6 +645,11 @@ func (a *API) handleUserManagers(w http.ResponseWriter, r *http.Request, botID s
 			}
 			if body.ManagerID == "" {
 				http.Error(w, "manager_id is required", http.StatusBadRequest)
+				return
+			}
+			// Managers can only assign themselves; admins can assign anyone.
+			if callerRole != "admin" && body.ManagerID != callerID {
+				http.Error(w, "managers can only assign themselves", http.StatusForbidden)
 				return
 			}
 			// Validate bot exists and has "user" role (only bots can have managers).

--- a/internal/admin/api_auth_test.go
+++ b/internal/admin/api_auth_test.go
@@ -80,10 +80,18 @@ type stubUserStore struct{}
 
 func (s *stubUserStore) ListUsers() ([]UserSummary, error) { return nil, nil }
 func (s *stubUserStore) GetUser(id string) (*UserDetail, error) {
-	return &UserDetail{ID: id, Role: "manager", Channels: []UserChannelInfo{}, Managers: []ManagerAssignment{}}, nil
+	role := "user"
+	if strings.Contains(id, "mgr") || strings.Contains(id, "manager") || strings.Contains(id, "admin") {
+		role = "manager"
+	}
+	return &UserDetail{ID: id, Role: role, Channels: []UserChannelInfo{}, Managers: []ManagerAssignment{}}, nil
 }
 func (s *stubUserStore) CreateUser(req CreateUserRequest) (*UserDetail, error) {
-	return &UserDetail{ID: req.ID, Channels: []UserChannelInfo{}, Managers: []ManagerAssignment{}}, nil
+	role := "user"
+	if req.Role != nil {
+		role = *req.Role
+	}
+	return &UserDetail{ID: req.ID, Role: role, Channels: []UserChannelInfo{}, Managers: []ManagerAssignment{}}, nil
 }
 func (s *stubUserStore) UpdateUser(id string, req UpdateUserRequest) (*UserDetail, error) {
 	return &UserDetail{ID: id, Channels: []UserChannelInfo{}, Managers: []ManagerAssignment{}}, nil

--- a/internal/admin/api_auth_test.go
+++ b/internal/admin/api_auth_test.go
@@ -97,6 +97,9 @@ func (s *stubUserStore) ListManagers(botID string) ([]ManagerAssignment, error) 
 func (s *stubUserStore) ListManagedBots(managerID string) ([]ManagerAssignment, error) {
 	return []ManagerAssignment{}, nil
 }
+func (s *stubUserStore) ListUsersForManager(managerID string) ([]UserSummary, error) {
+	return []UserSummary{}, nil
+}
 func (s *stubUserStore) IsManagerOf(managerID, botID string) (bool, error) { return false, nil }
 
 // --- helpers ---
@@ -515,7 +518,6 @@ func TestManagerRole_AuthEnforcement(t *testing.T) {
 		body   string
 	}{
 		{http.MethodGet, "/admin/audit", ""},
-		{http.MethodPost, "/admin/users", `{"id":"test@x.com"}`},
 		{http.MethodGet, "/admin/llm-policies", ""},
 		{http.MethodGet, "/admin/evals", ""},
 	}
@@ -555,7 +557,7 @@ func TestManagerRole_AuthEnforcement(t *testing.T) {
 	})
 }
 
-// TestManagerUserList verifies that managers see a filtered user list.
+// TestManagerUserList verifies that managers see a filtered user list and can create bot users.
 func TestManagerUserList(t *testing.T) {
 	api := newTestAPI()
 
@@ -566,10 +568,24 @@ func TestManagerUserList(t *testing.T) {
 		}
 	})
 
-	t.Run("manager_cannot_create_user", func(t *testing.T) {
-		rr := doRequest(t, api, http.MethodPost, "/admin/users", managerToken, `{"id":"x@y.com"}`)
+	t.Run("manager_can_create_bot_user", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodPost, "/admin/users", managerToken, `{"id":"newbot@y.com"}`)
+		if rr.Code != http.StatusCreated {
+			t.Errorf("manager should create bot users, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("manager_cannot_create_admin_user", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodPost, "/admin/users", managerToken, `{"id":"x@y.com","role":"admin"}`)
 		if rr.Code != http.StatusForbidden {
-			t.Errorf("manager should not create users, got %d", rr.Code)
+			t.Errorf("manager should not create admin users, got %d", rr.Code)
+		}
+	})
+
+	t.Run("manager_cannot_create_manager_user", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodPost, "/admin/users", managerToken, `{"id":"x@y.com","role":"manager"}`)
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("manager should not create manager users, got %d", rr.Code)
 		}
 	})
 }

--- a/internal/admin/api_auth_test.go
+++ b/internal/admin/api_auth_test.go
@@ -609,10 +609,17 @@ func TestManagerBotAssignment_AuthEnforcement(t *testing.T) {
 		}
 	})
 
-	t.Run("manager_cannot_assign_manager", func(t *testing.T) {
-		rr := doRequest(t, api, http.MethodPost, "/admin/users/bot%40x.com/managers", managerToken, `{"manager_id":"mgr@x.com"}`)
+	t.Run("manager_can_self_assign", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodPost, "/admin/users/bot%40x.com/managers", managerToken, `{"manager_id":"manager@example.com"}`)
+		if rr.Code != http.StatusCreated {
+			t.Errorf("manager should self-assign, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("manager_cannot_assign_others", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodPost, "/admin/users/bot%40x.com/managers", managerToken, `{"manager_id":"other-mgr@x.com"}`)
 		if rr.Code != http.StatusForbidden {
-			t.Errorf("manager should not assign managers, got %d", rr.Code)
+			t.Errorf("manager should not assign others, got %d", rr.Code)
 		}
 	})
 

--- a/internal/admin/api_auth_test.go
+++ b/internal/admin/api_auth_test.go
@@ -80,15 +80,24 @@ type stubUserStore struct{}
 
 func (s *stubUserStore) ListUsers() ([]UserSummary, error) { return nil, nil }
 func (s *stubUserStore) GetUser(id string) (*UserDetail, error) {
-	return &UserDetail{ID: id, Channels: []UserChannelInfo{}}, nil
+	return &UserDetail{ID: id, Channels: []UserChannelInfo{}, Managers: []ManagerAssignment{}}, nil
 }
 func (s *stubUserStore) CreateUser(req CreateUserRequest) (*UserDetail, error) {
-	return &UserDetail{ID: req.ID, Channels: []UserChannelInfo{}}, nil
+	return &UserDetail{ID: req.ID, Channels: []UserChannelInfo{}, Managers: []ManagerAssignment{}}, nil
 }
 func (s *stubUserStore) UpdateUser(id string, req UpdateUserRequest) (*UserDetail, error) {
-	return &UserDetail{ID: id, Channels: []UserChannelInfo{}}, nil
+	return &UserDetail{ID: id, Channels: []UserChannelInfo{}, Managers: []ManagerAssignment{}}, nil
 }
-func (s *stubUserStore) DeleteUser(id string) error { return nil }
+func (s *stubUserStore) DeleteUser(id string) error                          { return nil }
+func (s *stubUserStore) AssignManager(botID, managerID string) error          { return nil }
+func (s *stubUserStore) UnassignManager(botID, managerID string) error        { return nil }
+func (s *stubUserStore) ListManagers(botID string) ([]ManagerAssignment, error) {
+	return []ManagerAssignment{}, nil
+}
+func (s *stubUserStore) ListManagedBots(managerID string) ([]ManagerAssignment, error) {
+	return []ManagerAssignment{}, nil
+}
+func (s *stubUserStore) IsManagerOf(managerID, botID string) (bool, error) { return false, nil }
 
 // --- helpers ---
 
@@ -506,7 +515,6 @@ func TestManagerRole_AuthEnforcement(t *testing.T) {
 		body   string
 	}{
 		{http.MethodGet, "/admin/audit", ""},
-		{http.MethodGet, "/admin/users", ""},
 		{http.MethodPost, "/admin/users", `{"id":"test@x.com"}`},
 		{http.MethodGet, "/admin/llm-policies", ""},
 		{http.MethodGet, "/admin/evals", ""},
@@ -543,6 +551,113 @@ func TestManagerRole_AuthEnforcement(t *testing.T) {
 		body := rr.Body.String()
 		if !strings.Contains(body, `"role":"manager"`) {
 			t.Errorf("login should return role:manager, got: %s", body)
+		}
+	})
+}
+
+// TestManagerUserList verifies that managers see a filtered user list.
+func TestManagerUserList(t *testing.T) {
+	api := newTestAPI()
+
+	t.Run("manager_gets_200_on_user_list", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodGet, "/admin/users", managerToken, "")
+		if rr.Code != http.StatusOK {
+			t.Errorf("manager should access GET /admin/users, got %d", rr.Code)
+		}
+	})
+
+	t.Run("manager_cannot_create_user", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodPost, "/admin/users", managerToken, `{"id":"x@y.com"}`)
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("manager should not create users, got %d", rr.Code)
+		}
+	})
+}
+
+// TestManagerBotAssignment_AuthEnforcement verifies auth on manager assignment endpoints.
+func TestManagerBotAssignment_AuthEnforcement(t *testing.T) {
+	api := newTestAPI()
+
+	t.Run("admin_can_assign_manager", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodPost, "/admin/users/bot%40x.com/managers", adminToken, `{"manager_id":"mgr@x.com"}`)
+		if rr.Code != http.StatusCreated {
+			t.Errorf("admin should assign managers, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("manager_cannot_assign_manager", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodPost, "/admin/users/bot%40x.com/managers", managerToken, `{"manager_id":"mgr@x.com"}`)
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("manager should not assign managers, got %d", rr.Code)
+		}
+	})
+
+	t.Run("no_token_returns_401", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodPost, "/admin/users/bot%40x.com/managers", "", `{"manager_id":"mgr@x.com"}`)
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("no token should return 401, got %d", rr.Code)
+		}
+	})
+
+	t.Run("admin_can_list_managers", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodGet, "/admin/users/bot%40x.com/managers", adminToken, "")
+		if rr.Code != http.StatusOK {
+			t.Errorf("admin should list managers, got %d", rr.Code)
+		}
+	})
+
+	t.Run("unrelated_manager_cannot_list_managers", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodGet, "/admin/users/bot%40x.com/managers", managerToken, "")
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("unrelated manager should get 403, got %d", rr.Code)
+		}
+	})
+
+	t.Run("admin_can_unassign_manager", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodDelete, "/admin/users/bot%40x.com/managers/mgr%40x.com", adminToken, "")
+		// May be 404 (assignment not found in stub) but should not be 401/403
+		if rr.Code == http.StatusUnauthorized || rr.Code == http.StatusForbidden {
+			t.Errorf("admin should pass auth on unassign, got %d", rr.Code)
+		}
+	})
+
+	t.Run("manager_cannot_unassign", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodDelete, "/admin/users/bot%40x.com/managers/mgr%40x.com", managerToken, "")
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("manager should not unassign, got %d", rr.Code)
+		}
+	})
+}
+
+// TestMeBots_AuthEnforcement verifies /admin/me/bots requires at least manager role.
+func TestMeBots_AuthEnforcement(t *testing.T) {
+	api := newTestAPI()
+
+	t.Run("admin_can_access", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodGet, "/admin/me/bots", adminToken, "")
+		if rr.Code != http.StatusOK {
+			t.Errorf("admin should access /admin/me/bots, got %d", rr.Code)
+		}
+	})
+
+	t.Run("manager_can_access", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodGet, "/admin/me/bots", managerToken, "")
+		if rr.Code != http.StatusOK {
+			t.Errorf("manager should access /admin/me/bots, got %d", rr.Code)
+		}
+	})
+
+	t.Run("user_gets_403", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodGet, "/admin/me/bots", nonAdminToken, "")
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("user should get 403 on /admin/me/bots, got %d", rr.Code)
+		}
+	})
+
+	t.Run("no_token_gets_401", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodGet, "/admin/me/bots", "", "")
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("no token should return 401, got %d", rr.Code)
 		}
 	})
 }

--- a/internal/admin/api_auth_test.go
+++ b/internal/admin/api_auth_test.go
@@ -80,7 +80,7 @@ type stubUserStore struct{}
 
 func (s *stubUserStore) ListUsers() ([]UserSummary, error) { return nil, nil }
 func (s *stubUserStore) GetUser(id string) (*UserDetail, error) {
-	return &UserDetail{ID: id, Channels: []UserChannelInfo{}, Managers: []ManagerAssignment{}}, nil
+	return &UserDetail{ID: id, Role: "manager", Channels: []UserChannelInfo{}, Managers: []ManagerAssignment{}}, nil
 }
 func (s *stubUserStore) CreateUser(req CreateUserRequest) (*UserDetail, error) {
 	return &UserDetail{ID: req.ID, Channels: []UserChannelInfo{}, Managers: []ManagerAssignment{}}, nil
@@ -627,6 +627,64 @@ func TestManagerBotAssignment_AuthEnforcement(t *testing.T) {
 			t.Errorf("manager should not unassign, got %d", rr.Code)
 		}
 	})
+}
+
+// TestAssignManager_RoleValidation verifies that only users with manager/admin role can be assigned.
+func TestAssignManager_RoleValidation(t *testing.T) {
+	userRoleStore := &roleAwareStubUserStore{
+		roles: map[string]string{
+			"bot@x.com":     "user",
+			"regular@x.com": "user",
+			"mgr@x.com":     "manager",
+		},
+	}
+	validator := &stubValidator{
+		tokens: map[string]stubUser{
+			adminToken: {userID: "admin@example.com", role: "admin"},
+		},
+	}
+	api := NewAPI(
+		&stubAuditReader{},
+		notifications.NewDispatcher(),
+		notifications.NewSSEChannel("web"),
+		validator,
+		userRoleStore,
+	)
+
+	t.Run("reject_user_role_as_manager", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodPost, "/admin/users/bot%40x.com/managers", adminToken, `{"manager_id":"regular@x.com"}`)
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("should reject user-role as manager, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("accept_manager_role", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodPost, "/admin/users/bot%40x.com/managers", adminToken, `{"manager_id":"mgr@x.com"}`)
+		if rr.Code != http.StatusCreated {
+			t.Errorf("should accept manager-role, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("reject_nonexistent_manager", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodPost, "/admin/users/bot%40x.com/managers", adminToken, `{"manager_id":"ghost@x.com"}`)
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("should reject nonexistent manager, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+// roleAwareStubUserStore returns users with configurable roles for validation tests.
+type roleAwareStubUserStore struct {
+	stubUserStore
+	roles map[string]string
+}
+
+func (s *roleAwareStubUserStore) GetUser(id string) (*UserDetail, error) {
+	role, exists := s.roles[id]
+	if !exists {
+		return nil, fmt.Errorf("user not found")
+	}
+	return &UserDetail{ID: id, Role: role, Channels: []UserChannelInfo{}, Managers: []ManagerAssignment{}}, nil
 }
 
 // TestMeBots_AuthEnforcement verifies /admin/me/bots requires at least manager role.

--- a/internal/admin/api_auth_test.go
+++ b/internal/admin/api_auth_test.go
@@ -700,7 +700,8 @@ func TestAssignManager_RoleValidation(t *testing.T) {
 // roleAwareStubUserStore returns users with configurable roles for validation tests.
 type roleAwareStubUserStore struct {
 	stubUserStore
-	roles map[string]string
+	roles       map[string]string
+	assignments map[string][]string // managerID -> []botID
 }
 
 func (s *roleAwareStubUserStore) GetUser(id string) (*UserDetail, error) {
@@ -709,6 +710,18 @@ func (s *roleAwareStubUserStore) GetUser(id string) (*UserDetail, error) {
 		return nil, fmt.Errorf("user not found")
 	}
 	return &UserDetail{ID: id, Role: role, Channels: []UserChannelInfo{}, Managers: []ManagerAssignment{}}, nil
+}
+
+func (s *roleAwareStubUserStore) IsManagerOf(managerID, botID string) (bool, error) {
+	if s.assignments == nil {
+		return false, nil
+	}
+	for _, b := range s.assignments[managerID] {
+		if b == botID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // TestMeBots_AuthEnforcement verifies /admin/me/bots requires at least manager role.
@@ -740,6 +753,69 @@ func TestMeBots_AuthEnforcement(t *testing.T) {
 		rr := doRequest(t, api, http.MethodGet, "/admin/me/bots", "", "")
 		if rr.Code != http.StatusUnauthorized {
 			t.Errorf("no token should return 401, got %d", rr.Code)
+		}
+	})
+}
+
+// TestManagerGetUserDetail verifies that managers can GET detail of their
+// assigned bots but not unassigned ones.
+func TestManagerGetUserDetail(t *testing.T) {
+	store := &roleAwareStubUserStore{
+		roles: map[string]string{
+			"bot@x.com":     "user",
+			"other@x.com":   "user",
+			"mgr@x.com":     "manager",
+		},
+		assignments: map[string][]string{
+			"mgr@x.com": {"bot@x.com"},
+		},
+	}
+	validator := &stubValidator{
+		tokens: map[string]stubUser{
+			adminToken:   {userID: "admin@example.com", role: "admin"},
+			managerToken: {userID: "mgr@x.com", role: "manager"},
+		},
+	}
+	api := NewAPI(
+		&stubAuditReader{},
+		notifications.NewDispatcher(),
+		notifications.NewSSEChannel("web"),
+		validator,
+		store,
+	)
+
+	t.Run("manager_can_view_assigned_bot", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodGet, "/admin/users/bot%40x.com", managerToken, "")
+		if rr.Code != http.StatusOK {
+			t.Errorf("manager should view assigned bot, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("manager_cannot_view_unassigned_bot", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodGet, "/admin/users/other%40x.com", managerToken, "")
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("manager should not view unassigned bot, got %d", rr.Code)
+		}
+	})
+
+	t.Run("manager_cannot_update_bot", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodPut, "/admin/users/bot%40x.com", managerToken, `{"role":"admin"}`)
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("manager should not update bot, got %d", rr.Code)
+		}
+	})
+
+	t.Run("manager_cannot_delete_bot", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodDelete, "/admin/users/bot%40x.com", managerToken, "")
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("manager should not delete bot, got %d", rr.Code)
+		}
+	})
+
+	t.Run("admin_can_view_any_user", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodGet, "/admin/users/other%40x.com", adminToken, "")
+		if rr.Code != http.StatusOK {
+			t.Errorf("admin should view any user, got %d: %s", rr.Code, rr.Body.String())
 		}
 	})
 }

--- a/internal/admin/api_auth_test.go
+++ b/internal/admin/api_auth_test.go
@@ -609,17 +609,10 @@ func TestManagerBotAssignment_AuthEnforcement(t *testing.T) {
 		}
 	})
 
-	t.Run("manager_can_self_assign", func(t *testing.T) {
-		rr := doRequest(t, api, http.MethodPost, "/admin/users/bot%40x.com/managers", managerToken, `{"manager_id":"manager@example.com"}`)
-		if rr.Code != http.StatusCreated {
-			t.Errorf("manager should self-assign, got %d: %s", rr.Code, rr.Body.String())
-		}
-	})
-
-	t.Run("manager_cannot_assign_others", func(t *testing.T) {
-		rr := doRequest(t, api, http.MethodPost, "/admin/users/bot%40x.com/managers", managerToken, `{"manager_id":"other-mgr@x.com"}`)
+	t.Run("manager_cannot_assign_manager", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodPost, "/admin/users/bot%40x.com/managers", managerToken, `{"manager_id":"mgr@x.com"}`)
 		if rr.Code != http.StatusForbidden {
-			t.Errorf("manager should not assign others, got %d", rr.Code)
+			t.Errorf("manager should not assign managers, got %d", rr.Code)
 		}
 	})
 

--- a/internal/admin/pg_user_store.go
+++ b/internal/admin/pg_user_store.go
@@ -101,6 +101,7 @@ type UserStore interface {
 	UnassignManager(botID, managerID string) error
 	ListManagers(botID string) ([]ManagerAssignment, error)
 	ListManagedBots(managerID string) ([]ManagerAssignment, error)
+	ListUsersForManager(managerID string) ([]UserSummary, error)
 	IsManagerOf(managerID, botID string) (bool, error)
 }
 
@@ -447,6 +448,34 @@ func (s *PGUserStore) ListManagedBots(managerID string) ([]ManagerAssignment, er
 			return nil, err
 		}
 		result = append(result, a)
+	}
+	return result, nil
+}
+
+func (s *PGUserStore) ListUsersForManager(managerID string) ([]UserSummary, error) {
+	ctx := context.Background()
+	rows, err := s.pool.Query(ctx, `
+		SELECT u.id, u.role, COALESCE(u.llm_policy_id, ''), u.created_at,
+		       COUNT(DISTINCT uc.id) AS channel_count
+		FROM users u
+		JOIN user_managers um ON um.bot_id = u.id
+		LEFT JOIN user_channels uc ON uc.user_id = u.id
+		WHERE um.manager_id = $1
+		GROUP BY u.id, u.role, u.llm_policy_id, u.created_at
+		ORDER BY u.created_at DESC
+	`, managerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := []UserSummary{}
+	for rows.Next() {
+		var u UserSummary
+		if err := rows.Scan(&u.ID, &u.Role, &u.LLMPolicyID, &u.CreatedAt, &u.ChannelCount); err != nil {
+			return nil, err
+		}
+		u.IsAdmin = roleIsAdmin(u.Role)
+		result = append(result, u)
 	}
 	return result, nil
 }

--- a/internal/admin/pg_user_store.go
+++ b/internal/admin/pg_user_store.go
@@ -26,13 +26,14 @@ type UserSummary struct {
 }
 
 type UserDetail struct {
-	ID          string            `json:"id"`
-	Role        string            `json:"role"`
-	IsAdmin     bool              `json:"is_admin"`
-	LLMPolicyID string            `json:"llm_policy_id,omitempty"`
-	CreatedAt   time.Time         `json:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at"`
-	Channels    []UserChannelInfo `json:"channels"`
+	ID          string              `json:"id"`
+	Role        string              `json:"role"`
+	IsAdmin     bool                `json:"is_admin"`
+	LLMPolicyID string              `json:"llm_policy_id,omitempty"`
+	CreatedAt   time.Time           `json:"created_at"`
+	UpdatedAt   time.Time           `json:"updated_at"`
+	Channels    []UserChannelInfo   `json:"channels"`
+	Managers    []ManagerAssignment `json:"managers"`
 }
 
 type UserChannelInfo struct {
@@ -40,6 +41,13 @@ type UserChannelInfo struct {
 	ChannelType      string `json:"channel_type"`
 	WebToken         string `json:"web_token,omitempty"`
 	GatewayAuthToken string `json:"gateway_auth_token,omitempty"`
+}
+
+type ManagerAssignment struct {
+	ID        string    `json:"id"`
+	BotID     string    `json:"bot_id"`
+	ManagerID string    `json:"manager_id"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // ---- Request types ----
@@ -89,6 +97,11 @@ type UserStore interface {
 	CreateUser(req CreateUserRequest) (*UserDetail, error)
 	UpdateUser(id string, req UpdateUserRequest) (*UserDetail, error)
 	DeleteUser(id string) error
+	AssignManager(botID, managerID string) error
+	UnassignManager(botID, managerID string) error
+	ListManagers(botID string) ([]ManagerAssignment, error)
+	ListManagedBots(managerID string) ([]ManagerAssignment, error)
+	IsManagerOf(managerID, botID string) (bool, error)
 }
 
 // ---- PGUserStore ----
@@ -164,6 +177,13 @@ func (s *PGUserStore) GetUser(id string) (*UserDetail, error) {
 		u.Channels = append(u.Channels, ch)
 	}
 	chanRows.Close()
+
+	// Fetch manager assignments
+	managers, err := s.ListManagers(id)
+	if err != nil {
+		return nil, err
+	}
+	u.Managers = managers
 
 	return &u, nil
 }
@@ -358,6 +378,86 @@ func (s *PGUserStore) GetUserByGatewayAuthToken(token string) (string, bool) {
 		return "", false
 	}
 	return userID, true
+}
+
+// ---- Manager assignment methods ----
+
+func (s *PGUserStore) AssignManager(botID, managerID string) error {
+	ctx := context.Background()
+	id := db.NewID("mgr")
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO user_managers(id, bot_id, manager_id)
+		VALUES($1, $2, $3)
+		ON CONFLICT (bot_id, manager_id) DO NOTHING
+	`, id, botID, managerID)
+	return err
+}
+
+func (s *PGUserStore) UnassignManager(botID, managerID string) error {
+	ctx := context.Background()
+	tag, err := s.pool.Exec(ctx, `
+		DELETE FROM user_managers WHERE bot_id = $1 AND manager_id = $2
+	`, botID, managerID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return errors.New("assignment not found")
+	}
+	return nil
+}
+
+func (s *PGUserStore) ListManagers(botID string) ([]ManagerAssignment, error) {
+	ctx := context.Background()
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, bot_id, manager_id, created_at
+		FROM user_managers WHERE bot_id = $1
+		ORDER BY created_at
+	`, botID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := []ManagerAssignment{}
+	for rows.Next() {
+		var a ManagerAssignment
+		if err := rows.Scan(&a.ID, &a.BotID, &a.ManagerID, &a.CreatedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, a)
+	}
+	return result, nil
+}
+
+func (s *PGUserStore) ListManagedBots(managerID string) ([]ManagerAssignment, error) {
+	ctx := context.Background()
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, bot_id, manager_id, created_at
+		FROM user_managers WHERE manager_id = $1
+		ORDER BY created_at
+	`, managerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := []ManagerAssignment{}
+	for rows.Next() {
+		var a ManagerAssignment
+		if err := rows.Scan(&a.ID, &a.BotID, &a.ManagerID, &a.CreatedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, a)
+	}
+	return result, nil
+}
+
+func (s *PGUserStore) IsManagerOf(managerID, botID string) (bool, error) {
+	ctx := context.Background()
+	var exists bool
+	err := s.pool.QueryRow(ctx, `
+		SELECT EXISTS(SELECT 1 FROM user_managers WHERE manager_id = $1 AND bot_id = $2)
+	`, managerID, botID).Scan(&exists)
+	return exists, err
 }
 
 // GetLLMPolicyForUser returns the LLM policy linked to the given user, or nil if none is set.

--- a/internal/admin/pg_user_store.go
+++ b/internal/admin/pg_user_store.go
@@ -427,6 +427,9 @@ func (s *PGUserStore) ListManagers(botID string) ([]ManagerAssignment, error) {
 		}
 		result = append(result, a)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -448,6 +451,9 @@ func (s *PGUserStore) ListManagedBots(managerID string) ([]ManagerAssignment, er
 			return nil, err
 		}
 		result = append(result, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return result, nil
 }
@@ -476,6 +482,9 @@ func (s *PGUserStore) ListUsersForManager(managerID string) ([]UserSummary, erro
 		}
 		u.IsAdmin = roleIsAdmin(u.Role)
 		result = append(result, u)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return result, nil
 }

--- a/internal/admin/pg_user_store.go
+++ b/internal/admin/pg_user_store.go
@@ -178,6 +178,9 @@ func (s *PGUserStore) GetUser(id string) (*UserDetail, error) {
 		u.Channels = append(u.Channels, ch)
 	}
 	chanRows.Close()
+	if err := chanRows.Err(); err != nil {
+		return nil, err
+	}
 
 	// Fetch manager assignments
 	managers, err := s.ListManagers(id)

--- a/internal/db/migrations/003_user_managers.sql
+++ b/internal/db/migrations/003_user_managers.sql
@@ -2,7 +2,7 @@
 -- Links manager users to the bots they oversee.
 
 CREATE TABLE IF NOT EXISTS user_managers (
-    id         TEXT PRIMARY KEY,
+    id         TEXT PRIMARY KEY,  -- "mgr_xxx" (generated via db.NewID("mgr"))
     bot_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     manager_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/internal/db/migrations/003_user_managers.sql
+++ b/internal/db/migrations/003_user_managers.sql
@@ -1,0 +1,13 @@
+-- Manager-bot assignment junction table.
+-- Links manager users to the bots they oversee.
+
+CREATE TABLE IF NOT EXISTS user_managers (
+    id         TEXT PRIMARY KEY,
+    bot_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    manager_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(bot_id, manager_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_managers_bot_id ON user_managers(bot_id);
+CREATE INDEX IF NOT EXISTS idx_user_managers_manager_id ON user_managers(manager_id);

--- a/web/e2e-manager-test.mjs
+++ b/web/e2e-manager-test.mjs
@@ -1,0 +1,221 @@
+import puppeteer from 'puppeteer'
+
+const BASE = 'http://localhost:8081'
+const ADMIN_TOKEN = 'admin-secret'
+const MANAGER_TOKEN = 'manager-secret'
+
+let browser
+let passed = 0
+let failed = 0
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error(`  FAIL: ${msg}`)
+    failed++
+  } else {
+    console.log(`  PASS: ${msg}`)
+    passed++
+  }
+}
+
+async function apiTest() {
+  console.log('\n=== API Tests ===')
+
+  // Test 1: Admin can assign manager to bot
+  console.log('\n[Test 1] Admin assigns manager to bot')
+  let res = await fetch(`${BASE}/admin/users/bot%40test.com/managers`, {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${ADMIN_TOKEN}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ manager_id: 'manager@test.com' }),
+  })
+  assert(res.status === 201, `POST assign manager returns 201, got ${res.status}`)
+
+  // Test 2: Admin can list managers for bot
+  console.log('\n[Test 2] Admin lists managers for bot')
+  res = await fetch(`${BASE}/admin/users/bot%40test.com/managers`, {
+    headers: { 'Authorization': `Bearer ${ADMIN_TOKEN}` },
+  })
+  assert(res.status === 200, `GET managers returns 200, got ${res.status}`)
+  const managers = await res.json()
+  assert(managers.length === 1, `Expected 1 manager, got ${managers.length}`)
+  assert(managers[0].manager_id === 'manager@test.com', `Manager is manager@test.com`)
+  assert(managers[0].bot_id === 'bot@test.com', `Bot is bot@test.com`)
+
+  // Test 3: Manager can list managers (is assigned)
+  console.log('\n[Test 3] Assigned manager can list managers')
+  res = await fetch(`${BASE}/admin/users/bot%40test.com/managers`, {
+    headers: { 'Authorization': `Bearer ${MANAGER_TOKEN}` },
+  })
+  assert(res.status === 200, `Assigned manager GET returns 200, got ${res.status}`)
+
+  // Test 4: Manager sees only assigned bots in user list
+  console.log('\n[Test 4] Manager sees filtered user list')
+  res = await fetch(`${BASE}/admin/users`, {
+    headers: { 'Authorization': `Bearer ${MANAGER_TOKEN}` },
+  })
+  assert(res.status === 200, `Manager GET /users returns 200, got ${res.status}`)
+  const users = await res.json()
+  assert(users.length === 1, `Manager sees 1 user, got ${users.length}`)
+  assert(users[0].id === 'bot@test.com', `Manager sees bot@test.com, got ${users[0]?.id}`)
+
+  // Test 5: Admin sees all users
+  console.log('\n[Test 5] Admin sees all users')
+  res = await fetch(`${BASE}/admin/users`, {
+    headers: { 'Authorization': `Bearer ${ADMIN_TOKEN}` },
+  })
+  const allUsers = await res.json()
+  assert(allUsers.length >= 3, `Admin sees >=3 users, got ${allUsers.length}`)
+
+  // Test 6: Manager cannot assign managers
+  console.log('\n[Test 6] Manager cannot assign managers')
+  res = await fetch(`${BASE}/admin/users/bot%40test.com/managers`, {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${MANAGER_TOKEN}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ manager_id: 'admin@test.com' }),
+  })
+  assert(res.status === 403, `Manager POST assign returns 403, got ${res.status}`)
+
+  // Test 7: Manager cannot unassign managers
+  console.log('\n[Test 7] Manager cannot unassign managers')
+  res = await fetch(`${BASE}/admin/users/bot%40test.com/managers/manager%40test.com`, {
+    method: 'DELETE',
+    headers: { 'Authorization': `Bearer ${MANAGER_TOKEN}` },
+  })
+  assert(res.status === 403, `Manager DELETE unassign returns 403, got ${res.status}`)
+
+  // Test 8: GET /admin/me/bots returns managed bots
+  console.log('\n[Test 8] GET /admin/me/bots')
+  res = await fetch(`${BASE}/admin/me/bots`, {
+    headers: { 'Authorization': `Bearer ${MANAGER_TOKEN}` },
+  })
+  assert(res.status === 200, `GET /me/bots returns 200, got ${res.status}`)
+  const bots = await res.json()
+  assert(bots.length === 1, `Manager has 1 bot, got ${bots.length}`)
+  assert(bots[0].id === 'bot@test.com', `Bot is bot@test.com`)
+
+  // Test 9: User detail includes managers
+  console.log('\n[Test 9] User detail includes managers array')
+  res = await fetch(`${BASE}/admin/users/bot%40test.com`, {
+    headers: { 'Authorization': `Bearer ${ADMIN_TOKEN}` },
+  })
+  const botDetail = await res.json()
+  assert(Array.isArray(botDetail.managers), `managers is array`)
+  assert(botDetail.managers.length === 1, `1 manager in detail, got ${botDetail.managers?.length}`)
+
+  // Test 10: Admin can unassign manager
+  console.log('\n[Test 10] Admin unassigns manager')
+  res = await fetch(`${BASE}/admin/users/bot%40test.com/managers/manager%40test.com`, {
+    method: 'DELETE',
+    headers: { 'Authorization': `Bearer ${ADMIN_TOKEN}` },
+  })
+  assert(res.status === 200, `DELETE unassign returns 200, got ${res.status}`)
+
+  // Verify unassignment
+  res = await fetch(`${BASE}/admin/users/bot%40test.com/managers`, {
+    headers: { 'Authorization': `Bearer ${ADMIN_TOKEN}` },
+  })
+  const remaining = await res.json()
+  assert(remaining.length === 0, `No managers remaining after unassign`)
+
+  // Test 11: Manager no longer sees bot in user list
+  console.log('\n[Test 11] Manager sees empty list after unassignment')
+  res = await fetch(`${BASE}/admin/users`, {
+    headers: { 'Authorization': `Bearer ${MANAGER_TOKEN}` },
+  })
+  const emptyList = await res.json()
+  assert(emptyList.length === 0, `Manager sees 0 users after unassign, got ${emptyList.length}`)
+}
+
+async function browserTest() {
+  console.log('\n=== Browser Tests ===')
+
+  // Re-assign manager for browser tests
+  await fetch(`${BASE}/admin/users/bot%40test.com/managers`, {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${ADMIN_TOKEN}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ manager_id: 'manager@test.com' }),
+  })
+
+  browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'] })
+  const page = await browser.newPage()
+
+  // Test 12: Admin login and navigate to user detail
+  console.log('\n[Test 12] Admin login + user detail shows managers section')
+  await page.goto(`${BASE}/#/`)
+  await page.waitForSelector('#token')
+  await page.type('#token', ADMIN_TOKEN)
+  await page.click('button[type="submit"]')
+  await page.waitForSelector('nav', { timeout: 5000 })
+
+  // Navigate to users
+  await page.click('a[href="#/users"]')
+  await page.waitForSelector('table', { timeout: 5000 })
+
+  // Click on bot@test.com
+  const botRow = await page.waitForSelector('td >> text/bot@test.com', { timeout: 3000 }).catch(() => null)
+  if (botRow) {
+    await botRow.click()
+  } else {
+    // Try alternative: find a link/row for bot@test.com
+    await page.evaluate(() => {
+      const rows = document.querySelectorAll('tr')
+      for (const row of rows) {
+        if (row.textContent?.includes('bot@test.com')) {
+          row.querySelector('td')?.click()
+          break
+        }
+      }
+    })
+  }
+
+  await new Promise(r => setTimeout(r, 1500))
+
+  // Check for Managers section
+  const pageContent = await page.content()
+  const hasManagersSection = pageContent.includes('Managers')
+  assert(hasManagersSection, 'User detail page has Managers section')
+
+  const hasManagerEmail = pageContent.includes('manager@test.com')
+  assert(hasManagerEmail, 'Managers section shows manager@test.com')
+
+  // Test 13: Manager login sees filtered user list (use incognito context)
+  console.log('\n[Test 13] Manager login sees only assigned bots')
+  const ctx2 = await browser.createBrowserContext()
+  const page2 = await ctx2.newPage()
+  await page2.goto(`${BASE}/#/`)
+  await page2.waitForSelector('#token', { timeout: 5000 })
+  await page2.type('#token', MANAGER_TOKEN)
+  await page2.click('button[type="submit"]')
+  await page2.waitForSelector('nav', { timeout: 5000 })
+
+  // Navigate to users
+  await page2.click('a[href="#/users"]')
+  await new Promise(r => setTimeout(r, 1500))
+
+  const page2Content = await page2.content()
+  const seesBotUser = page2Content.includes('bot@test.com')
+  assert(seesBotUser, 'Manager sees bot@test.com in user list')
+
+  const seesAdminUser = page2Content.includes('admin@test.com')
+  assert(!seesAdminUser, 'Manager does NOT see admin@test.com')
+
+  await ctx2.close()
+  await browser.close()
+}
+
+async function main() {
+  try {
+    await apiTest()
+    await browserTest()
+  } catch (err) {
+    console.error('Test error:', err)
+    failed++
+  } finally {
+    if (browser) await browser.close().catch(() => {})
+  }
+
+  console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`)
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+main()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,6 +1,6 @@
 import type {
   AuditEntry, LLMPolicy, PolicyStats,
-  UserSummary, UserDetail,
+  UserSummary, UserDetail, ManagerAssignment,
   CreateUserRequest, UpdateUserRequest,
   EvalRun, EvalResult, AuditLabel, LLMResponse, StaticRule, ChatMessage,
 } from '../types'
@@ -192,6 +192,29 @@ export async function updateUser(id: string, req: UpdateUserRequest): Promise<Us
 
 export async function deleteUser(id: string): Promise<void> {
   await fetchAPI(`/users/${encodeURIComponent(id)}`, { method: 'DELETE' })
+}
+
+// ---- Manager assignment API ----
+
+export async function getManagers(botId: string): Promise<ManagerAssignment[]> {
+  return fetchAPI<ManagerAssignment[]>(`/users/${encodeURIComponent(botId)}/managers`)
+}
+
+export async function assignManager(botId: string, managerId: string): Promise<void> {
+  await fetchAPI(`/users/${encodeURIComponent(botId)}/managers`, {
+    method: 'POST',
+    body: JSON.stringify({ manager_id: managerId }),
+  })
+}
+
+export async function unassignManager(botId: string, managerId: string): Promise<void> {
+  await fetchAPI(`/users/${encodeURIComponent(botId)}/managers/${encodeURIComponent(managerId)}`, {
+    method: 'DELETE',
+  })
+}
+
+export async function getManagedBots(): Promise<ManagerAssignment[]> {
+  return fetchAPI<ManagerAssignment[]>('/me/bots')
 }
 
 // ---- Eval API ----

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -213,8 +213,8 @@ export async function unassignManager(botId: string, managerId: string): Promise
   })
 }
 
-export async function getManagedBots(): Promise<ManagerAssignment[]> {
-  return fetchAPI<ManagerAssignment[]>('/me/bots')
+export async function getManagedBots(): Promise<UserSummary[]> {
+  return fetchAPI<UserSummary[]>('/me/bots')
 }
 
 // ---- Eval API ----

--- a/web/src/components/UserDetailPage.tsx
+++ b/web/src/components/UserDetailPage.tsx
@@ -1,12 +1,12 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import {
-  getUser, getPolicies,
+  getUser, getUsers, getPolicies,
   updateUser, deleteUser,
   createPolicy,
 } from '../api/client'
 import type {
-  LLMPolicy, UserDetail,
+  LLMPolicy, UserDetail, UserSummary,
   UpdateUserRequest,
 } from '../types'
 import { UserDetailView } from './UsersPanel'
@@ -16,15 +16,21 @@ export function UserDetailPage() {
   const navigate = useNavigate()
   const [user, setUser] = useState<UserDetail | null>(null)
   const [policies, setPolicies] = useState<LLMPolicy[]>([])
+  const [allUsers, setAllUsers] = useState<UserSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [creatingDraft, setCreatingDraft] = useState(false)
 
+  const loadUser = useCallback(() => {
+    if (!id) return Promise.resolve()
+    return getUser(id).then(setUser)
+  }, [id])
+
   useEffect(() => {
     if (!id) return
     setLoading(true)
-    Promise.all([getUser(id), getPolicies()])
-      .then(([u, p]) => { setUser(u); setPolicies(p) })
+    Promise.all([getUser(id), getPolicies(), getUsers()])
+      .then(([u, p, users]) => { setUser(u); setPolicies(p); setAllUsers(users) })
       .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load user'))
       .finally(() => setLoading(false))
   }, [id])
@@ -59,8 +65,7 @@ export function UserDetailPage() {
       const start = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
       const message = `Analyze traffic for ${id} from ${start} to ${end}. Based on what you find, build a complete policy.`
       navigate(`/policies/${draft.id}`, { state: { startAgentMessage: message } })
-    } catch (err) {
-      // fallback: just navigate to policies
+    } catch {
       navigate('/policies')
     } finally {
       setCreatingDraft(false)
@@ -75,6 +80,8 @@ export function UserDetailPage() {
       onEditUser={handleEditUser}
       onDeleteUser={handleDeleteUser}
       onSuggestPolicy={creatingDraft ? undefined : handleSuggestPolicy}
+      onRefreshUser={loadUser}
+      allUsers={allUsers}
     />
   )
 }

--- a/web/src/components/UserDetailPage.tsx
+++ b/web/src/components/UserDetailPage.tsx
@@ -1,36 +1,37 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import {
-  getUser, getUsers, getPolicies,
+  getUser, getPolicies,
   updateUser, deleteUser,
   createPolicy,
 } from '../api/client'
 import type {
-  LLMPolicy, UserDetail, UserSummary,
+  LLMPolicy, UserDetail,
   UpdateUserRequest,
 } from '../types'
 import { UserDetailView } from './UsersPanel'
+import { useAuth } from '../contexts/AuthContext'
 
 export function UserDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const { allUsers } = useAuth()
   const [user, setUser] = useState<UserDetail | null>(null)
   const [policies, setPolicies] = useState<LLMPolicy[]>([])
-  const [allUsers, setAllUsers] = useState<UserSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [creatingDraft, setCreatingDraft] = useState(false)
 
   const loadUser = useCallback(() => {
     if (!id) return Promise.resolve()
-    return getUser(id).then(setUser)
+    return getUser(id).then(setUser).catch((err) => setError(err instanceof Error ? err.message : 'Failed to refresh user'))
   }, [id])
 
   useEffect(() => {
     if (!id) return
     setLoading(true)
-    Promise.all([getUser(id), getPolicies(), getUsers()])
-      .then(([u, p, users]) => { setUser(u); setPolicies(p); setAllUsers(users) })
+    Promise.all([getUser(id), getPolicies()])
+      .then(([u, p]) => { setUser(u); setPolicies(p) })
       .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load user'))
       .finally(() => setLoading(false))
   }, [id])

--- a/web/src/components/UsersPanel.tsx
+++ b/web/src/components/UsersPanel.tsx
@@ -74,6 +74,7 @@ const btnDanger = 'px-3 py-1.5 bg-red-600 text-white text-xs font-medium rounded
 // ---- Create User Modal ----
 
 function CreateUserModal({ onClose, onSave }: { onClose: () => void; onSave: (req: CreateUserRequest) => Promise<unknown> }) {
+  const { isAdmin } = useAuth()
   const [form, setForm] = useState<CreateUserRequest>({ id: '', role: 'user', web_token: '' })
   const [saving, setSaving] = useState(false)
   const [err, setErr] = useState<string | null>(null)
@@ -137,13 +138,15 @@ function CreateUserModal({ onClose, onSave }: { onClose: () => void; onSave: (re
             </button>
           </div>
         </Field>
-        <Field label="Role">
-          <select className={inputClass} value={form.role ?? 'user'} onChange={(e) => setForm({ ...form, role: e.target.value as 'admin' | 'manager' | 'user' })}>
-            <option value="user">User</option>
-            <option value="manager">Manager</option>
-            <option value="admin">Admin</option>
-          </select>
-        </Field>
+        {isAdmin && (
+          <Field label="Role">
+            <select className={inputClass} value={form.role ?? 'user'} onChange={(e) => setForm({ ...form, role: e.target.value as 'admin' | 'manager' | 'user' })}>
+              <option value="user">User</option>
+              <option value="manager">Manager</option>
+              <option value="admin">Admin</option>
+            </select>
+          </Field>
+        )}
         {err && <p className="text-red-600 text-sm">{err}</p>}
         <div className="flex justify-end gap-2 pt-2">
           <button type="button" className={btnSecondary} onClick={onClose}>Cancel</button>
@@ -163,6 +166,7 @@ function EditUserModal({
   onClose: () => void
   onSave: (req: UpdateUserRequest) => Promise<unknown>
 }) {
+  const { isAdmin } = useAuth()
   const [form, setForm] = useState<UpdateUserRequest>({
     role: (initial.role as 'admin' | 'manager' | 'user') ?? (initial.is_admin ? 'admin' : 'user'),
     llm_policy_id: initial.llm_policy_id,
@@ -230,13 +234,15 @@ function EditUserModal({
           </div>
           <p className="text-xs text-gray-400 mt-1">Rotating invalidates the current token immediately.</p>
         </Field>
-        <Field label="Role">
-          <select className={inputClass} value={form.role ?? 'user'} onChange={(e) => setForm({ ...form, role: e.target.value as 'admin' | 'manager' | 'user' })}>
-            <option value="user">User</option>
-            <option value="manager">Manager</option>
-            <option value="admin">Admin</option>
-          </select>
-        </Field>
+        {isAdmin && (
+          <Field label="Role">
+            <select className={inputClass} value={form.role ?? 'user'} onChange={(e) => setForm({ ...form, role: e.target.value as 'admin' | 'manager' | 'user' })}>
+              <option value="user">User</option>
+              <option value="manager">Manager</option>
+              <option value="admin">Admin</option>
+            </select>
+          </Field>
+        )}
         {err && <p className="text-red-600 text-sm">{err}</p>}
         <div className="flex justify-end gap-2 pt-2">
           <button type="button" className={btnSecondary} onClick={onClose}>Cancel</button>
@@ -514,7 +520,6 @@ export function UserDetailView({
 
 export function UsersPanel() {
   const navigate = useNavigate()
-  const { isAdmin } = useAuth()
   const { users, loading, error, createUser } = useUsers()
 
   const [showCreate, setShowCreate] = useState(false)
@@ -538,7 +543,7 @@ export function UsersPanel() {
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold text-gray-800">Users</h2>
-        {isAdmin && <button onClick={() => setShowCreate(true)} className={btnPrimary}>+ Create User</button>}
+        <button onClick={() => setShowCreate(true)} className={btnPrimary}>+ Create User</button>
       </div>
 
       {users.length === 0 ? (

--- a/web/src/components/UsersPanel.tsx
+++ b/web/src/components/UsersPanel.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useUsers } from '../hooks/useUsers'
-import { getPolicies } from '../api/client'
+import { useAuth } from '../contexts/AuthContext'
+import { getPolicies, assignManager, unassignManager } from '../api/client'
 import type {
-  LLMPolicy, UserChannelInfo, UserDetail,
+  LLMPolicy, UserChannelInfo, UserDetail, ManagerAssignment,
   CreateUserRequest, UpdateUserRequest,
 } from '../types'
 
@@ -301,12 +302,99 @@ function ChannelsSection({ channels, onEdit }: { channels: UserChannelInfo[]; on
   )
 }
 
+// ---- Managers section (admin only) ----
+
+function ManagersSection({ managers, botId, allUsers, onAssign, onUnassign }: {
+  managers: ManagerAssignment[]
+  botId: string
+  allUsers: { id: string; role: string }[]
+  onAssign: (managerId: string) => Promise<void>
+  onUnassign: (managerId: string) => Promise<void>
+}) {
+  const { isAdmin } = useAuth()
+  const [adding, setAdding] = useState(false)
+  const [selectedManager, setSelectedManager] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const assignedIds = new Set(managers.map((m) => m.manager_id))
+  const availableManagers = allUsers.filter(
+    (u) => (u.role === 'manager' || u.role === 'admin') && u.id !== botId && !assignedIds.has(u.id)
+  )
+
+  const handleAssign = async () => {
+    if (!selectedManager) return
+    setBusy(true)
+    try {
+      await onAssign(selectedManager)
+      setSelectedManager('')
+      setAdding(false)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleUnassign = async (managerId: string) => {
+    if (!confirm(`Remove ${managerId} as manager?`)) return
+    await onUnassign(managerId)
+  }
+
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-base font-semibold text-gray-800">Managers</h3>
+        {isAdmin && !adding && (
+          <button onClick={() => setAdding(true)} className={btnSecondary + ' text-xs'}>
+            Add Manager
+          </button>
+        )}
+      </div>
+      <div className="bg-white rounded-xl border border-gray-200 divide-y divide-gray-100">
+        {managers.length === 0 && !adding && (
+          <div className="px-4 py-3 text-sm text-gray-400">No managers assigned</div>
+        )}
+        {managers.map((m) => (
+          <div key={m.id} className="px-4 py-3 flex items-center gap-4 text-sm">
+            <span className="flex-1 font-medium text-gray-700">{m.manager_id}</span>
+            <span className="text-xs text-gray-400">{new Date(m.created_at).toLocaleDateString()}</span>
+            {isAdmin && (
+              <button onClick={() => handleUnassign(m.manager_id)} className="text-xs text-red-600 hover:underline">
+                Remove
+              </button>
+            )}
+          </div>
+        ))}
+        {adding && (
+          <div className="px-4 py-3 flex items-center gap-2">
+            <select
+              value={selectedManager}
+              onChange={(e) => setSelectedManager(e.target.value)}
+              className="flex-1 px-2 py-1 border border-gray-300 rounded text-sm"
+            >
+              <option value="">Select a manager…</option>
+              {availableManagers.map((u) => (
+                <option key={u.id} value={u.id}>{u.id}</option>
+              ))}
+            </select>
+            <button onClick={handleAssign} disabled={!selectedManager || busy} className={btnSecondary + ' text-xs'}>
+              {busy ? 'Adding…' : 'Add'}
+            </button>
+            <button onClick={() => setAdding(false)} className="text-xs text-gray-500 hover:underline">
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
 // ---- Detail view ----
 
 export function UserDetailView({
   user, onBack, policies,
   onEditUser, onDeleteUser,
-  onSuggestPolicy,
+  onSuggestPolicy, onRefreshUser,
+  allUsers,
 }: {
   user: UserDetail | null
   onBack: () => void
@@ -314,6 +402,8 @@ export function UserDetailView({
   onEditUser: (req: UpdateUserRequest) => Promise<unknown>
   onDeleteUser: () => Promise<unknown>
   onSuggestPolicy?: () => void
+  onRefreshUser?: () => void
+  allUsers?: { id: string; role: string }[]
 }) {
   const navigate = useNavigate()
   const [showEdit, setShowEdit] = useState(false)
@@ -326,6 +416,16 @@ export function UserDetailView({
     setDeleting(true)
     try { await onDeleteUser() }
     finally { setDeleting(false) }
+  }
+
+  const handleAssignManager = async (managerId: string) => {
+    await assignManager(user.id, managerId)
+    onRefreshUser?.()
+  }
+
+  const handleUnassignManager = async (managerId: string) => {
+    await unassignManager(user.id, managerId)
+    onRefreshUser?.()
   }
 
   const webChannel = user.channels.find((c) => c.channel_type === 'web')
@@ -370,6 +470,15 @@ export function UserDetailView({
       <ChannelsSection
         channels={user.channels}
         onEdit={() => setShowEdit(true)}
+      />
+
+      {/* Managers */}
+      <ManagersSection
+        managers={user.managers ?? []}
+        botId={user.id}
+        allUsers={allUsers ?? []}
+        onAssign={handleAssignManager}
+        onUnassign={handleUnassignManager}
       />
 
       {showEdit && (

--- a/web/src/components/UsersPanel.tsx
+++ b/web/src/components/UsersPanel.tsx
@@ -321,13 +321,18 @@ function ManagersSection({ managers, botId, allUsers, onAssign, onUnassign }: {
     (u) => (u.role === 'manager' || u.role === 'admin') && u.id !== botId && !assignedIds.has(u.id)
   )
 
+  const [error, setError] = useState<string | null>(null)
+
   const handleAssign = async () => {
     if (!selectedManager) return
     setBusy(true)
+    setError(null)
     try {
       await onAssign(selectedManager)
       setSelectedManager('')
       setAdding(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to assign manager')
     } finally {
       setBusy(false)
     }
@@ -335,7 +340,12 @@ function ManagersSection({ managers, botId, allUsers, onAssign, onUnassign }: {
 
   const handleUnassign = async (managerId: string) => {
     if (!confirm(`Remove ${managerId} as manager?`)) return
-    await onUnassign(managerId)
+    setError(null)
+    try {
+      await onUnassign(managerId)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to remove manager')
+    }
   }
 
   return (
@@ -348,6 +358,7 @@ function ManagersSection({ managers, botId, allUsers, onAssign, onUnassign }: {
           </button>
         )}
       </div>
+      {error && <p className="text-red-600 text-sm mb-2">{error}</p>}
       <div className="bg-white rounded-xl border border-gray-200 divide-y divide-gray-100">
         {managers.length === 0 && !adding && (
           <div className="px-4 py-3 text-sm text-gray-400">No managers assigned</div>
@@ -503,6 +514,7 @@ export function UserDetailView({
 
 export function UsersPanel() {
   const navigate = useNavigate()
+  const { isAdmin } = useAuth()
   const { users, loading, error, createUser } = useUsers()
 
   const [showCreate, setShowCreate] = useState(false)
@@ -526,7 +538,7 @@ export function UsersPanel() {
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold text-gray-800">Users</h2>
-        <button onClick={() => setShowCreate(true)} className={btnPrimary}>+ Create User</button>
+        {isAdmin && <button onClick={() => setShowCreate(true)} className={btnPrimary}>+ Create User</button>}
       </div>
 
       {users.length === 0 ? (

--- a/web/src/components/UsersPanel.tsx
+++ b/web/src/components/UsersPanel.tsx
@@ -437,12 +437,12 @@ export function UserDetailView({
 
   const handleAssignManager = async (managerId: string) => {
     await assignManager(user.id, managerId)
-    onRefreshUser?.()
+    await onRefreshUser?.()
   }
 
   const handleUnassignManager = async (managerId: string) => {
     await unassignManager(user.id, managerId)
-    onRefreshUser?.()
+    await onRefreshUser?.()
   }
 
   const webChannel = user.channels.find((c) => c.channel_type === 'web')
@@ -489,14 +489,16 @@ export function UserDetailView({
         onEdit={() => setShowEdit(true)}
       />
 
-      {/* Managers */}
-      <ManagersSection
-        managers={user.managers ?? []}
-        botId={user.id}
-        allUsers={allUsers ?? []}
-        onAssign={handleAssignManager}
-        onUnassign={handleUnassignManager}
-      />
+      {/* Managers (only for bot users) */}
+      {user.role === 'user' && (
+        <ManagersSection
+          managers={user.managers ?? []}
+          botId={user.id}
+          allUsers={allUsers ?? []}
+          onAssign={handleAssignManager}
+          onUnassign={handleUnassignManager}
+        />
+      )}
 
       {showEdit && (
         <EditUserModal

--- a/web/src/components/UsersPanel.tsx
+++ b/web/src/components/UsersPanel.tsx
@@ -308,7 +308,7 @@ function ChannelsSection({ channels, onEdit }: { channels: UserChannelInfo[]; on
   )
 }
 
-// ---- Managers section (admin only) ----
+// ---- Managers section ----
 
 function ManagersSection({ managers, botId, allUsers, onAssign, onUnassign }: {
   managers: ManagerAssignment[]

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -141,10 +141,18 @@ export interface UserChannelInfo {
   gateway_auth_token?: string
 }
 
+export interface ManagerAssignment {
+  id: string
+  bot_id: string
+  manager_id: string
+  created_at: string
+}
+
 export interface UserDetail extends Omit<UserSummary, 'channel_count' | 'llm_policy_id'> {
   llm_policy_id?: string
   updated_at: string
   channels: UserChannelInfo[]
+  managers: ManagerAssignment[]
 }
 
 export interface CreateUserRequest {


### PR DESCRIPTION
## Summary

Adds manager-bot assignment infrastructure — a junction table linking managers to the bots they oversee, with scoped access control throughout:

- **Manager-bot junction table** (`user_managers`) with FK constraints and indexes
- **Manager self-service**: managers can create and manage their own bot users (auto-assigned on creation)
- **Scoped user list**: `GET /admin/users` returns only assigned bots for managers; full list for admins
- **Scoped user detail**: `GET /admin/users/{id}` allows managers to view their assigned bots (PUT/DELETE remain admin-only)
- **Assignment CRUD**: admins can assign/unassign managers to any bot
- **Role validation**: only "user" role bots can have managers assigned; only "manager"/"admin" roles can be assigned as managers
- **Auto-assign with rollback**: manager-created bots are auto-assigned; if assignment fails, the bot is deleted
- **Frontend**: ManagersSection on bot detail page (admin can add/remove any manager), role selector hidden for non-admins
- **Consistent API types**: `/admin/me/bots` returns `[]UserSummary` for both admin and manager paths

### Authorization matrix

| Endpoint | Admin | Manager | User |
|----------|-------|---------|------|
| `GET /admin/users` | Full list | Assigned bots only | 403 |
| `POST /admin/users` | Any role | Bot users only (auto-assigned) | 403 |
| `GET /admin/users/{id}` | Any user | Assigned bots only | 403 |
| `PUT /admin/users/{id}` | Yes | 403 | 403 |
| `DELETE /admin/users/{id}` | Yes | 403 | 403 |
| `POST /admin/users/{id}/managers` | Yes | 403 | 403 |
| `DELETE /admin/users/{id}/managers/{mid}` | Yes | 403 | 403 |
| `GET /admin/users/{id}/managers` | Yes | If assigned | 403 |
| `GET /admin/me/bots` | All bots | Assigned bots | 403 |

## Test plan

- [x] Manager can create bot users (forced role "user", auto-assigned)
- [x] Manager cannot create admin/manager users
- [x] Manager cannot assign/unassign managers (admin-only)
- [x] Manager can GET detail of assigned bots
- [x] Manager cannot GET/PUT/DELETE unassigned bots
- [x] Admin can assign/unassign any manager
- [x] Role validation rejects non-manager/admin as assignee
- [x] Role validation rejects non-bot as assignment target
- [x] Auto-assign rollback on failure
- [x] `go vet`, `staticcheck`, `tsc --noEmit` all pass
- [x] Frontend: role selector hidden for non-admins, ManagersSection only on bot users

🤖 Generated with [Claude Code](https://claude.com/claude-code)