### PR TITLE
feat(auth): scoped audit trail and SSE for managers

### DIFF
--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -319,13 +319,15 @@ func (a *API) handleMeBots(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, http.StatusOK, bots)
 }
 
-// handleAuditLog returns audit entries with optional filters
+// handleAuditLog returns audit entries with optional filters.
+// Admins see all entries; managers see only entries for bots they manage.
 func (a *API) handleAuditLog(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if _, ok := a.requireAdmin(w, r); !ok {
+	callerID, callerRole, ok := a.requireRole(w, r, "manager")
+	if !ok {
 		return
 	}
 
@@ -339,6 +341,31 @@ func (a *API) handleAuditLog(w http.ResponseWriter, r *http.Request) {
 		Channel:    query.Get("channel"),
 		Method:     query.Get("method"),
 		PolicyID:   query.Get("policy_id"),
+	}
+
+	// Managers can only see audit for bots they manage.
+	if callerRole != "admin" {
+		managedBotIDs, err := a.managedBotIDs(callerID)
+		if err != nil {
+			respondError(w, http.StatusInternalServerError, "failed to resolve managed bots", err)
+			return
+		}
+		if filter.UserID != "" {
+			if !contains(managedBotIDs, filter.UserID) {
+				http.Error(w, "Forbidden", http.StatusForbidden)
+				return
+			}
+		} else if len(managedBotIDs) == 0 {
+			respondJSON(w, http.StatusOK, map[string]interface{}{
+				"entries":  []types.AuditEntry{},
+				"offset":   0,
+				"limit":    defaultAuditLogLimit,
+				"has_more": false,
+			})
+			return
+		} else {
+			filter.UserIDs = managedBotIDs
+		}
 	}
 
 	// Parse cache_hit filter
@@ -398,17 +425,28 @@ func (a *API) handleAuditLog(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleSSE handles Server-Sent Events connections. Requires admin authentication.
+// handleSSE handles Server-Sent Events connections.
+// Admins receive all events; managers receive only events for their managed bots.
 func (a *API) handleSSE(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	userID, ok := a.requireAdmin(w, r)
+	callerID, callerRole, ok := a.requireRole(w, r, "manager")
 	if !ok {
 		return
 	}
-	a.sseChannel.ServeHTTPForUser(w, r, userID)
+
+	if callerRole == "admin" {
+		a.sseChannel.ServeHTTPForUserScoped(w, r, callerID, nil)
+	} else {
+		botIDs, err := a.managedBotIDs(callerID)
+		if err != nil {
+			respondError(w, http.StatusInternalServerError, "failed to resolve managed bots", err)
+			return
+		}
+		a.sseChannel.ServeHTTPForUserScoped(w, r, callerID, botIDs)
+	}
 }
 
 // handleHealth returns basic health information
@@ -1442,4 +1480,26 @@ func respondJSON(w http.ResponseWriter, status int, data interface{}) {
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		slog.Error("error encoding JSON response", "error", err)
 	}
+}
+
+// managedBotIDs returns the user IDs of bots managed by the given manager.
+func (a *API) managedBotIDs(managerID string) ([]string, error) {
+	assignments, err := a.userStore.ListManagedBots(managerID)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, len(assignments))
+	for i, asn := range assignments {
+		ids[i] = asn.BotID
+	}
+	return ids, nil
+}
+
+func contains(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/admin/api_auth_test.go
+++ b/internal/admin/api_auth_test.go
@@ -525,7 +525,6 @@ func TestManagerRole_AuthEnforcement(t *testing.T) {
 		path   string
 		body   string
 	}{
-		{http.MethodGet, "/admin/audit", ""},
 		{http.MethodGet, "/admin/llm-policies", ""},
 		{http.MethodGet, "/admin/evals", ""},
 	}
@@ -538,6 +537,14 @@ func TestManagerRole_AuthEnforcement(t *testing.T) {
 			}
 		})
 	}
+
+	// Managers can access audit (scoped to managed bots)
+	t.Run("manager_can_access_audit", func(t *testing.T) {
+		rr := doRequest(t, api, http.MethodGet, "/admin/audit", managerToken, "")
+		if rr.Code == http.StatusForbidden || rr.Code == http.StatusUnauthorized {
+			t.Errorf("manager should access /admin/audit, got %d", rr.Code)
+		}
+	})
 
 	t.Run("manager_can_access_me", func(t *testing.T) {
 		rr := doRequest(t, api, http.MethodGet, "/admin/me", managerToken, "")

--- a/internal/admin/pg_audit_reader.go
+++ b/internal/admin/pg_audit_reader.go
@@ -113,6 +113,7 @@ type PolicyStats struct {
 type AuditFilter struct {
 	ID                string
 	UserID            string
+	UserIDs           []string // restrict to entries from any of these user IDs
 	Decision          string
 	ApprovedBy        string
 	CacheHit          *bool
@@ -245,6 +246,15 @@ func buildAuditQueryConditions(filter AuditFilter) (conds []string, args []inter
 	}
 	if filter.UserID != "" {
 		add("al.user_id = $%d", filter.UserID)
+	}
+	if len(filter.UserIDs) > 0 {
+		placeholders := make([]string, len(filter.UserIDs))
+		for i, uid := range filter.UserIDs {
+			placeholders[i] = fmt.Sprintf("$%d", idx)
+			args = append(args, uid)
+			idx++
+		}
+		conds = append(conds, fmt.Sprintf("al.user_id IN (%s)", strings.Join(placeholders, ", ")))
 	}
 	if filter.Decision != "" {
 		add("al.decision = $%d", filter.Decision)

--- a/internal/admin/scoped_audit_test.go
+++ b/internal/admin/scoped_audit_test.go
@@ -1,0 +1,151 @@
+package admin
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/brexhq/CrabTrap/internal/notifications"
+	"github.com/brexhq/CrabTrap/pkg/types"
+)
+
+func newScopedAuditAPI(t *testing.T) (*API, *PGAuditReader, *PGUserStore) {
+	t.Helper()
+	validator := &stubValidator{
+		tokens: map[string]stubUser{
+			adminToken:   {userID: "admin@example.com", role: "admin"},
+			managerToken: {userID: "manager@example.com", role: "manager"},
+		},
+	}
+	reader := NewPGAuditReader(testPool)
+	userStore := NewPGUserStore(testPool)
+	api := NewAPI(
+		reader,
+		notifications.NewDispatcher(), notifications.NewSSEChannel("web"),
+		validator, userStore,
+	)
+	return api, reader, userStore
+}
+
+func TestScopedAudit_ManagerSeesOnlyManagedBots(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no test database")
+	}
+	truncateTables(t)
+	api, reader, userStore := newScopedAuditAPI(t)
+
+	mgrRole := "manager"
+	userStore.CreateUser(CreateUserRequest{ID: "admin@example.com", IsAdmin: true})
+	userStore.CreateUser(CreateUserRequest{ID: "manager@example.com", Role: &mgrRole})
+	userStore.CreateUser(CreateUserRequest{ID: "bot-a@example.com"})
+	userStore.CreateUser(CreateUserRequest{ID: "bot-b@example.com"})
+
+	userStore.AssignManager("bot-a@example.com", "manager@example.com")
+
+	reader.Add(types.AuditEntry{UserID: "bot-a@example.com", Method: "GET", URL: "https://api.example.com/a", Decision: "ALLOW", Timestamp: time.Now()})
+	reader.Add(types.AuditEntry{UserID: "bot-b@example.com", Method: "GET", URL: "https://api.example.com/b", Decision: "DENY", Timestamp: time.Now()})
+
+	rr := doRequest(t, api, http.MethodGet, "/admin/audit", managerToken, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("manager audit: got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Entries []types.AuditEntry `json:"entries"`
+	}
+	decodeJSON(t, rr, &resp)
+	if len(resp.Entries) != 1 {
+		t.Fatalf("manager should see 1 entry, got %d", len(resp.Entries))
+	}
+	if resp.Entries[0].UserID != "bot-a@example.com" {
+		t.Errorf("expected bot-a entry, got user_id=%s", resp.Entries[0].UserID)
+	}
+
+	rr = doRequest(t, api, http.MethodGet, "/admin/audit", adminToken, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("admin audit: got %d", rr.Code)
+	}
+	decodeJSON(t, rr, &resp)
+	if len(resp.Entries) != 2 {
+		t.Errorf("admin should see 2 entries, got %d", len(resp.Entries))
+	}
+}
+
+func TestScopedAudit_ManagerCanFilterToManagedBot(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no test database")
+	}
+	truncateTables(t)
+	api, reader, userStore := newScopedAuditAPI(t)
+
+	mgrRole := "manager"
+	userStore.CreateUser(CreateUserRequest{ID: "manager@example.com", Role: &mgrRole})
+	userStore.CreateUser(CreateUserRequest{ID: "bot-a@example.com"})
+	userStore.AssignManager("bot-a@example.com", "manager@example.com")
+
+	reader.Add(types.AuditEntry{UserID: "bot-a@example.com", Method: "POST", URL: "https://api.example.com/x", Decision: "DENY", Timestamp: time.Now()})
+
+	rr := doRequest(t, api, http.MethodGet, "/admin/audit?user_id=bot-a@example.com", managerToken, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("manager filter to managed bot: got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Entries []types.AuditEntry `json:"entries"`
+	}
+	decodeJSON(t, rr, &resp)
+	if len(resp.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(resp.Entries))
+	}
+}
+
+func TestScopedAudit_ManagerCannotFilterToUnmanagedBot(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no test database")
+	}
+	truncateTables(t)
+	api, _, userStore := newScopedAuditAPI(t)
+
+	mgrRole := "manager"
+	userStore.CreateUser(CreateUserRequest{ID: "manager@example.com", Role: &mgrRole})
+	userStore.CreateUser(CreateUserRequest{ID: "bot-a@example.com"})
+	userStore.CreateUser(CreateUserRequest{ID: "bot-b@example.com"})
+	userStore.AssignManager("bot-a@example.com", "manager@example.com")
+
+	rr := doRequest(t, api, http.MethodGet, "/admin/audit?user_id=bot-b@example.com", managerToken, "")
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("manager filtering to unmanaged bot should be 403, got %d", rr.Code)
+	}
+}
+
+func TestScopedAudit_ManagerWithNoBotsSeesNothing(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no test database")
+	}
+	truncateTables(t)
+	api, reader, userStore := newScopedAuditAPI(t)
+
+	mgrRole := "manager"
+	userStore.CreateUser(CreateUserRequest{ID: "manager@example.com", Role: &mgrRole})
+	userStore.CreateUser(CreateUserRequest{ID: "bot-a@example.com"})
+
+	reader.Add(types.AuditEntry{UserID: "bot-a@example.com", Method: "GET", URL: "https://api.example.com/a", Decision: "ALLOW", Timestamp: time.Now()})
+
+	rr := doRequest(t, api, http.MethodGet, "/admin/audit", managerToken, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("manager audit with no bots: got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Entries []types.AuditEntry `json:"entries"`
+	}
+	decodeJSON(t, rr, &resp)
+	if len(resp.Entries) != 0 {
+		t.Errorf("manager with no bots should see 0 entries, got %d", len(resp.Entries))
+	}
+}
+
+func TestScopedAudit_UserRoleCannotAccessAudit(t *testing.T) {
+	api := newTestAPI()
+	rr := doRequest(t, api, http.MethodGet, "/admin/audit", nonAdminToken, "")
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("user role should get 403 on audit, got %d", rr.Code)
+	}
+}

--- a/internal/notifications/sse.go
+++ b/internal/notifications/sse.go
@@ -179,14 +179,17 @@ func (s *SSEChannel) ServeHTTPForUserScoped(w http.ResponseWriter, r *http.Reque
 		select {
 		case <-r.Context().Done():
 			close(client.done)
+			slog.Debug("SSE client disconnected", "client_id", clientID)
 			return
 
 		case message, ok := <-client.messages:
 			if !ok {
 				close(client.done)
+				slog.Debug("SSE client messages channel closed, stopping", "client_id", clientID)
 				return
 			}
 			if _, err := w.Write(message); err != nil {
+				slog.Error("error writing to SSE client", "client_id", clientID, "error", err)
 				close(client.done)
 				return
 			}

--- a/internal/notifications/sse.go
+++ b/internal/notifications/sse.go
@@ -13,10 +13,11 @@ import (
 
 // SSEClient represents a connected SSE client.
 type SSEClient struct {
-	id       string
-	userID   string
-	messages chan []byte
-	done     chan struct{}
+	id            string
+	userID        string
+	messages      chan []byte
+	done          chan struct{}
+	allowedBotIDs map[string]bool // if non-nil, only receive events for these user IDs
 }
 
 // SSEChannel implements the Channel interface for Server-Sent Events.
@@ -42,7 +43,8 @@ func (s *SSEChannel) Name() string {
 
 // Notify delivers event to the appropriate SSE clients.
 // If event.TargetUserID is set, only that user's connection receives it.
-// Otherwise the event is fanned out to all connected clients.
+// Otherwise the event is fanned out to all connected clients, respecting
+// per-client allowedBotIDs filters.
 func (s *SSEChannel) Notify(event Event) error {
 	data, err := json.Marshal(event)
 	if err != nil {
@@ -59,7 +61,13 @@ func (s *SSEChannel) Notify(event Event) error {
 			s.deliver(client, message)
 		}
 	} else {
+		sourceUserID := eventSourceUserID(event)
 		for _, client := range s.clients {
+			if client.allowedBotIDs != nil && sourceUserID != "" {
+				if !client.allowedBotIDs[sourceUserID] {
+					continue
+				}
+			}
 			s.deliver(client, message)
 		}
 	}
@@ -169,4 +177,82 @@ func (s *SSEChannel) ClientCount() int {
 
 func formatSSEMessage(eventType string, data []byte) []byte {
 	return []byte(fmt.Sprintf("event: %s\ndata: %s\n\n", eventType, data))
+}
+
+// eventSourceUserID extracts the originating bot/user ID from an event's payload.
+func eventSourceUserID(event Event) string {
+	if event.Data == nil {
+		return ""
+	}
+	type hasUserID interface {
+		GetUserID() string
+	}
+	if src, ok := event.Data.(hasUserID); ok {
+		return src.GetUserID()
+	}
+	return ""
+}
+
+// ServeHTTPForUserScoped handles an SSE connection that only receives events
+// for the specified set of bot user IDs. Pass nil for allowedBotIDs to receive all events.
+func (s *SSEChannel) ServeHTTPForUserScoped(w http.ResponseWriter, r *http.Request, userID string, allowedBotIDs []string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	var rndBuf [8]byte
+	_, _ = rand.Read(rndBuf[:])
+	clientID := fmt.Sprintf("%s-%d-%s", r.RemoteAddr, time.Now().UnixNano(), hex.EncodeToString(rndBuf[:]))
+	client := &SSEClient{
+		id:       clientID,
+		userID:   userID,
+		messages: make(chan []byte, 100),
+		done:     make(chan struct{}),
+	}
+	if allowedBotIDs != nil {
+		client.allowedBotIDs = make(map[string]bool, len(allowedBotIDs))
+		for _, id := range allowedBotIDs {
+			client.allowedBotIDs[id] = true
+		}
+	}
+
+	s.setClient(client)
+	defer s.removeClient(client)
+
+	slog.Debug("SSE client connected", "client_id", clientID, "user_id", userID, "scoped", allowedBotIDs != nil)
+
+	fmt.Fprintf(w, "data: {\"type\":\"connected\",\"client_id\":\"%s\"}\n\n", clientID)
+	flusher.Flush()
+
+	heartbeat := time.NewTicker(30 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			close(client.done)
+			return
+
+		case message, ok := <-client.messages:
+			if !ok {
+				close(client.done)
+				return
+			}
+			if _, err := w.Write(message); err != nil {
+				close(client.done)
+				return
+			}
+			flusher.Flush()
+
+		case <-heartbeat.C:
+			fmt.Fprintf(w, ":heartbeat\n\n")
+			flusher.Flush()
+		}
+	}
 }

--- a/internal/notifications/sse.go
+++ b/internal/notifications/sse.go
@@ -89,65 +89,7 @@ func (s *SSEChannel) deliver(client *SSEClient, message []byte) {
 // If the user already has a connection, it is replaced by the new one.
 // userID must be non-empty; call sites are responsible for enforcing auth.
 func (s *SSEChannel) ServeHTTPForUser(w http.ResponseWriter, r *http.Request, userID string) {
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
-		return
-	}
-
-	var rndBuf [8]byte
-	_, _ = rand.Read(rndBuf[:])
-	clientID := fmt.Sprintf("%s-%d-%s", r.RemoteAddr, time.Now().UnixNano(), hex.EncodeToString(rndBuf[:]))
-	client := &SSEClient{
-		id:       clientID,
-		userID:   userID,
-		messages: make(chan []byte, 100),
-		done:     make(chan struct{}),
-	}
-
-	s.setClient(client)
-	defer s.removeClient(client)
-
-	slog.Debug("SSE client connected", "client_id", clientID, "user_id", userID)
-
-	fmt.Fprintf(w, "data: {\"type\":\"connected\",\"client_id\":\"%s\"}\n\n", clientID)
-	flusher.Flush()
-
-	heartbeat := time.NewTicker(30 * time.Second)
-	defer heartbeat.Stop()
-
-	for {
-		select {
-		case <-r.Context().Done():
-			close(client.done)
-			slog.Debug("SSE client disconnected", "client_id", clientID)
-			return
-
-		case message, ok := <-client.messages:
-			if !ok {
-				// Channel was closed because this connection was replaced
-				// by a newer one for the same user. Exit immediately to
-				// avoid a tight spin loop on the closed channel.
-				close(client.done)
-				slog.Debug("SSE client messages channel closed, stopping", "client_id", clientID)
-				return
-			}
-			if _, err := w.Write(message); err != nil {
-				slog.Error("error writing to SSE client", "client_id", clientID, "error", err)
-				close(client.done)
-				return
-			}
-			flusher.Flush()
-
-		case <-heartbeat.C:
-			fmt.Fprintf(w, ":heartbeat\n\n")
-			flusher.Flush()
-		}
-	}
+	s.ServeHTTPForUserScoped(w, r, userID, nil)
 }
 
 func (s *SSEChannel) setClient(client *SSEClient) {

--- a/internal/notifications/sse.go
+++ b/internal/notifications/sse.go
@@ -63,8 +63,8 @@ func (s *SSEChannel) Notify(event Event) error {
 	} else {
 		sourceUserID := eventSourceUserID(event)
 		for _, client := range s.clients {
-			if client.allowedBotIDs != nil && sourceUserID != "" {
-				if !client.allowedBotIDs[sourceUserID] {
+			if client.allowedBotIDs != nil {
+				if sourceUserID == "" || !client.allowedBotIDs[sourceUserID] {
 					continue
 				}
 			}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -215,3 +215,5 @@ type AuditEntry struct {
 	LLMResponseID    string      `json:"llm_response_id,omitempty"`  // FK to llm_responses; set when channel="llm"
 	LLMPolicyID      string      `json:"llm_policy_id,omitempty"`    // Policy that evaluated this request (set when channel="llm")
 }
+
+func (e *AuditEntry) GetUserID() string { return e.UserID }


### PR DESCRIPTION
## Summary

- Managers can now view the audit trail (`GET /admin/audit`), scoped to bots they manage
- Managers can connect to SSE events (`GET /admin/events`), receiving only events for their bots
- Admins retain full unscoped access to both endpoints
- If a manager has no assigned bots, they get an empty result set (not an error)
- Managers filtering by `user_id` are validated against their managed bot set (403 if not their bot)

### Authorization matrix (changes from PR #18)

| Endpoint | Admin | Manager | User |
|----------|-------|---------|------|
| `GET /admin/audit` | All entries | Managed bots only | 403 |
| `GET /admin/events` (SSE) | All events | Managed bot events only | 403 |

### Implementation

- `AuditFilter.UserIDs []string` — new field, generates `IN (...)` clause
- `handleAuditLog` — relaxed from `requireAdmin` to `requireRole("manager")` with scoping
- `handleSSE` — relaxed from `requireAdmin` to `requireRole("manager")` with per-client filter
- `SSEClient.allowedBotIDs` — delivery-time filter map checked during fan-out
- `ServeHTTPForUserScoped` — new method that sets up scoped SSE connections
- `AuditEntry.GetUserID()` — interface method for SSE event source extraction

## Test plan

- [x] Manager sees only audit entries for managed bots
- [x] Manager can filter by `user_id` to a managed bot
- [x] Manager cannot filter to unmanaged bot (403)
- [x] Manager with no bots sees empty results
- [x] User role cannot access audit (403)
- [x] Admin sees all entries (unchanged)
- [x] All existing tests pass (16 packages green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)