### PR TITLE
feat: notification channels — schema, CRUD API, and web UI (1/3)

### DIFF
--- a/internal/admin/api.go
+++ b/internal/admin/api.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/brexhq/CrabTrap/internal/alerting"
 	"github.com/brexhq/CrabTrap/internal/approval"
 	"github.com/brexhq/CrabTrap/internal/builder"
 	"github.com/brexhq/CrabTrap/internal/eval"
@@ -41,17 +42,19 @@ type UserResolver interface {
 
 // API provides admin endpoints for the gateway
 type API struct {
-	reader         AuditReaderIface
-	dispatcher     *notifications.Dispatcher
-	sseChannel     *notifications.SSEChannel
-	tokenValidator WebTokenValidator    // may be nil
-	userStore      UserStore            // may be nil
-	policyStore    llmpolicy.Store      // may be nil
-	evalStore      eval.Store           // may be nil
-	evalJudge      *judge.LLMJudge      // may be nil — used only for eval background runs
-	agent          *builder.PolicyAgent // may be nil — used by agent endpoint
-	serverCtx      context.Context      // cancelled on server shutdown; used for background work
-	secureCookie   bool                 // when true, auth cookies are set with the Secure flag
+	reader            AuditReaderIface
+	dispatcher        *notifications.Dispatcher
+	sseChannel        *notifications.SSEChannel
+	tokenValidator    WebTokenValidator    // may be nil
+	userStore         UserStore            // may be nil
+	policyStore       llmpolicy.Store      // may be nil
+	evalStore         eval.Store           // may be nil
+	evalJudge         *judge.LLMJudge      // may be nil — used only for eval background runs
+	agent             *builder.PolicyAgent // may be nil — used by agent endpoint
+	notificationStore alerting.Store       // may be nil
+	alertService      *alerting.Service    // may be nil — used for test-send
+	serverCtx         context.Context      // cancelled on server shutdown; used for background work
+	secureCookie      bool                 // when true, auth cookies are set with the Secure flag
 
 	runCancelsMu sync.Mutex
 	runCancels   map[string]context.CancelCauseFunc // keyed by run ID; cleaned up on completion
@@ -83,6 +86,11 @@ func (a *API) SetEvalRunner(store eval.Store, j *judge.LLMJudge) {
 // SetAgent configures the PolicyAgent used by POST /{id}/agent.
 func (a *API) SetAgent(ag *builder.PolicyAgent) {
 	a.agent = ag
+}
+
+// SetAlertService configures the alerting service used by test-send endpoint.
+func (a *API) SetAlertService(svc *alerting.Service) {
+	a.alertService = svc
 }
 
 // SetServerContext sets a context that will be cancelled when the server shuts
@@ -208,6 +216,10 @@ func (a *API) RegisterRoutes(mux *http.ServeMux) {
 
 	// LLM response lookup
 	mux.HandleFunc("/admin/llm-responses/", a.handleLLMResponse)
+
+	// Notification channel endpoints
+	mux.HandleFunc("/admin/notification-channels", a.handleNotificationChannels)
+	mux.HandleFunc("/admin/notification-channels/", a.handleNotificationChannelAction)
 }
 
 // extractWebToken extracts the bearer token from the request.

--- a/internal/admin/notification_handlers.go
+++ b/internal/admin/notification_handlers.go
@@ -1,0 +1,220 @@
+package admin
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/brexhq/CrabTrap/internal/alerting"
+)
+
+// SetNotificationStore configures the alerting store used by notification channel endpoints.
+func (a *API) SetNotificationStore(s alerting.Store) {
+	a.notificationStore = s
+}
+
+// handleNotificationChannels handles GET (list) and POST (create) for /admin/notification-channels.
+func (a *API) handleNotificationChannels(w http.ResponseWriter, r *http.Request) {
+	callerID, callerRole, ok := a.requireRole(w, r, "manager")
+	if !ok {
+		return
+	}
+	if a.notificationStore == nil {
+		http.Error(w, "Notification channels not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		var channels []alerting.NotificationChannel
+		var err error
+		if callerRole == "admin" {
+			channels, err = a.notificationStore.ListChannelsForOwner(r.Context(), "")
+		} else {
+			channels, err = a.notificationStore.ListChannelsForOwner(r.Context(), callerID)
+		}
+		if err != nil {
+			respondError(w, http.StatusInternalServerError, "failed to list channels", err)
+			return
+		}
+		respondJSON(w, http.StatusOK, channels)
+
+	case http.MethodPost:
+		limitBody(w, r, maxBodySize)
+		var req struct {
+			BotID       string `json:"bot_id"`
+			ChannelType string `json:"channel_type"`
+			Destination string `json:"destination"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		if req.ChannelType == "" || req.Destination == "" {
+			http.Error(w, "channel_type and destination are required", http.StatusBadRequest)
+			return
+		}
+		if a.alertService != nil && a.alertService.SenderFor(req.ChannelType) == nil {
+			http.Error(w, "unsupported channel_type: "+req.ChannelType, http.StatusBadRequest)
+			return
+		}
+		if req.BotID != "" && callerRole != "admin" {
+			if a.userStore == nil {
+				http.Error(w, "User store not available", http.StatusServiceUnavailable)
+				return
+			}
+			isMgr, err := a.userStore.IsManagerOf(callerID, req.BotID)
+			if err != nil || !isMgr {
+				http.Error(w, "Forbidden: you do not manage this bot", http.StatusForbidden)
+				return
+			}
+		}
+		ch := &alerting.NotificationChannel{
+			OwnerID:     callerID,
+			BotID:       req.BotID,
+			ChannelType: req.ChannelType,
+			Destination: req.Destination,
+			Enabled:     true,
+		}
+		if err := a.notificationStore.CreateChannel(r.Context(), ch); err != nil {
+			respondError(w, http.StatusInternalServerError, "failed to create channel", err)
+			return
+		}
+		respondJSON(w, http.StatusCreated, ch)
+
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleNotificationChannelAction handles /admin/notification-channels/{id} and /admin/notification-channels/{id}/test.
+func (a *API) handleNotificationChannelAction(w http.ResponseWriter, r *http.Request) {
+	callerID, callerRole, ok := a.requireRole(w, r, "manager")
+	if !ok {
+		return
+	}
+	if a.notificationStore == nil {
+		http.Error(w, "Notification channels not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	const prefix = "/admin/notification-channels/"
+	remaining := strings.TrimPrefix(r.URL.Path, prefix)
+	if remaining == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Split: "notch_abc" or "notch_abc/test"
+	parts := strings.SplitN(remaining, "/", 2)
+	id := parts[0]
+	subPath := ""
+	if len(parts) > 1 {
+		subPath = parts[1]
+	}
+
+	if id == "" {
+		http.NotFound(w, r)
+		return
+	}
+	if subPath != "" && subPath != "test" {
+		http.NotFound(w, r)
+		return
+	}
+	isTest := subPath == "test"
+
+	ch, err := a.notificationStore.GetChannel(r.Context(), id)
+	if err != nil {
+		respondError(w, http.StatusNotFound, "channel not found", err)
+		return
+	}
+
+	// Auth: must be owner or admin
+	if callerRole != "admin" && ch.OwnerID != callerID {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	if isTest {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if a.alertService == nil {
+			http.Error(w, "Alerting service not available", http.StatusServiceUnavailable)
+			return
+		}
+		msg := alerting.Message{
+			BotID:   "test-bot",
+			Method:  "GET",
+			Pattern: "api.example.com/test",
+			Reason:  "This is a test notification from CrabTrap",
+		}
+		sender := a.alertService.SenderFor(ch.ChannelType)
+		if sender == nil {
+			http.Error(w, "No sender configured for channel type: "+ch.ChannelType, http.StatusBadRequest)
+			return
+		}
+		if err := sender.Send(r.Context(), ch.Destination, msg); err != nil {
+			respondError(w, http.StatusBadGateway, "test send failed", err)
+			return
+		}
+		respondJSON(w, http.StatusOK, map[string]string{"status": "sent"})
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		respondJSON(w, http.StatusOK, ch)
+
+	case http.MethodPut:
+		limitBody(w, r, maxBodySize)
+		var req struct {
+			ChannelType string `json:"channel_type"`
+			Destination string `json:"destination"`
+			Enabled     *bool  `json:"enabled"`
+		}
+		if !decodeBody(w, r, &req) {
+			return
+		}
+		channelType := ch.ChannelType
+		destination := ch.Destination
+		enabled := ch.Enabled
+		if req.ChannelType != "" {
+			channelType = req.ChannelType
+		}
+		if req.Destination != "" {
+			destination = req.Destination
+		}
+		if req.Enabled != nil {
+			enabled = *req.Enabled
+		}
+		if a.alertService != nil && a.alertService.SenderFor(channelType) == nil {
+			http.Error(w, "unsupported channel_type: "+channelType, http.StatusBadRequest)
+			return
+		}
+		if err := a.notificationStore.UpdateChannel(r.Context(), id, channelType, destination, enabled); err != nil {
+			respondError(w, http.StatusInternalServerError, "failed to update channel", err)
+			return
+		}
+		updated, err := a.notificationStore.GetChannel(r.Context(), id)
+		if err != nil {
+			respondError(w, http.StatusInternalServerError, "updated but failed to read back", err)
+			return
+		}
+		respondJSON(w, http.StatusOK, updated)
+
+	case http.MethodDelete:
+		if err := a.notificationStore.DeleteChannel(r.Context(), id); err != nil {
+			if errors.Is(err, alerting.ErrNotFound) {
+				respondError(w, http.StatusNotFound, "channel not found", err)
+			} else {
+				respondError(w, http.StatusInternalServerError, "failed to delete channel", err)
+			}
+			return
+		}
+		respondJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}

--- a/internal/admin/notification_handlers.go
+++ b/internal/admin/notification_handlers.go
@@ -53,7 +53,7 @@ func (a *API) handleNotificationChannels(w http.ResponseWriter, r *http.Request)
 			http.Error(w, "channel_type and destination are required", http.StatusBadRequest)
 			return
 		}
-		if a.alertService != nil && a.alertService.SenderFor(req.ChannelType) == nil {
+		if !validChannelType(a, req.ChannelType) {
 			http.Error(w, "unsupported channel_type: "+req.ChannelType, http.StatusBadRequest)
 			return
 		}
@@ -188,7 +188,7 @@ func (a *API) handleNotificationChannelAction(w http.ResponseWriter, r *http.Req
 		if req.Enabled != nil {
 			enabled = *req.Enabled
 		}
-		if a.alertService != nil && a.alertService.SenderFor(channelType) == nil {
+		if !validChannelType(a, channelType) {
 			http.Error(w, "unsupported channel_type: "+channelType, http.StatusBadRequest)
 			return
 		}
@@ -216,5 +216,20 @@ func (a *API) handleNotificationChannelAction(w http.ResponseWriter, r *http.Req
 
 	default:
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// validChannelType checks whether a channel_type is supported. If the alert
+// service is wired, it checks registered senders. Otherwise falls back to a
+// static allowlist so validation works even before the service is configured.
+func validChannelType(a *API, channelType string) bool {
+	if a.alertService != nil {
+		return a.alertService.SenderFor(channelType) != nil
+	}
+	switch channelType {
+	case "slack":
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/alerting/sender.go
+++ b/internal/alerting/sender.go
@@ -1,0 +1,131 @@
+package alerting
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Message represents a denial notification payload.
+type Message struct {
+	BotID   string
+	Method  string       // set for immediate single-denial alerts
+	Pattern string       // set for immediate single-denial alerts
+	Reason  string       // set for immediate single-denial alerts
+	Denials []DenialInfo // set for periodic digests (multiple patterns)
+	Summary string       // LLM-generated digest summary (periodic only)
+	URL     string       // link to CrabTrap audit trail
+}
+
+// Sender delivers a notification message to a destination.
+// Implementations are registered by channel_type (e.g., "slack").
+// To add a new channel type, implement this interface and register it
+// via Service.RegisterSender.
+type Sender interface {
+	Send(ctx context.Context, destination string, msg Message) error
+}
+
+// SlackSender posts messages to Slack using the Bot API (chat.postMessage).
+type SlackSender struct {
+	botToken string
+	client   *http.Client
+}
+
+func NewSlackSender(botToken string) *SlackSender {
+	return &SlackSender{
+		botToken: botToken,
+		client:   &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (s *SlackSender) Send(ctx context.Context, destination string, msg Message) error {
+	var text string
+
+	if msg.Summary != "" {
+		// Periodic digest
+		text = fmt.Sprintf(":bar_chart: *Denial digest* for `%s`\n\n%s",
+			slackEscape(msg.BotID), slackEscape(msg.Summary))
+		if len(msg.Denials) > 0 {
+			text += "\n\nPatterns blocked:"
+			for _, d := range msg.Denials {
+				text += fmt.Sprintf("\n• `%s`", slackEscape(d.Pattern))
+			}
+		}
+	} else {
+		// Immediate single-denial alert
+		text = fmt.Sprintf(":no_entry: *Denial alert* for `%s`\n*%s %s*",
+			slackEscape(msg.BotID), slackEscape(msg.Method), slackEscape(msg.Pattern))
+		if msg.Reason != "" {
+			text += fmt.Sprintf("\nReason: %s", slackEscape(msg.Reason))
+		}
+	}
+
+	if msg.URL != "" {
+		text += fmt.Sprintf("\n<%s|View in CrabTrap>", slackEscapeURL(msg.URL))
+	}
+
+	payload := map[string]interface{}{
+		"channel": destination,
+		"text":    text,
+		"blocks": []map[string]interface{}{
+			{
+				"type": "section",
+				"text": map[string]string{
+					"type": "mrkdwn",
+					"text": text,
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("slack: marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://slack.com/api/chat.postMessage", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("slack: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Authorization", "Bearer "+s.botToken)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("slack: send: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("slack: unexpected status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("slack: decode response: %w", err)
+	}
+	if !result.OK {
+		return fmt.Errorf("slack: API error: %s", result.Error)
+	}
+	return nil
+}
+
+func slackEscape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	return s
+}
+
+func slackEscapeURL(s string) string {
+	s = strings.ReplaceAll(s, ">", "%3E")
+	s = strings.ReplaceAll(s, "|", "%7C")
+	return s
+}

--- a/internal/alerting/service.go
+++ b/internal/alerting/service.go
@@ -1,0 +1,20 @@
+package alerting
+
+// Service is the alerting service. In this layer it only provides sender
+// registration and lookup for channel type validation. The dispatch logic
+// is added in a subsequent PR.
+type Service struct {
+	senders map[string]Sender
+}
+
+func NewService() *Service {
+	return &Service{senders: make(map[string]Sender)}
+}
+
+func (s *Service) RegisterSender(channelType string, sender Sender) {
+	s.senders[channelType] = sender
+}
+
+func (s *Service) SenderFor(channelType string) Sender {
+	return s.senders[channelType]
+}

--- a/internal/alerting/store.go
+++ b/internal/alerting/store.go
@@ -1,0 +1,234 @@
+package alerting
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/brexhq/CrabTrap/internal/db"
+)
+
+type NotificationChannel struct {
+	ID          string    `json:"id"`
+	OwnerID     string    `json:"owner_id"`
+	BotID       string    `json:"bot_id,omitempty"`
+	ChannelType string    `json:"channel_type"`
+	Destination string    `json:"destination"`
+	Enabled     bool      `json:"enabled"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+type Store interface {
+	ListChannelsForOwner(ctx context.Context, ownerID string) ([]NotificationChannel, error)
+	ListChannelsForBot(ctx context.Context, botID string) ([]NotificationChannel, error)
+	GetChannel(ctx context.Context, id string) (*NotificationChannel, error)
+	CreateChannel(ctx context.Context, ch *NotificationChannel) error
+	UpdateChannel(ctx context.Context, id string, channelType, destination string, enabled bool) error
+	DeleteChannel(ctx context.Context, id string) error
+	CheckCooldown(ctx context.Context, botID, pattern string) (bool, error)
+	RecordNotification(ctx context.Context, botID, method, pattern string, cooldownUntil time.Time) error
+	ListRecentDenials(ctx context.Context) (map[string][]DenialInfo, error)
+	MarkDigested(ctx context.Context, botID string) error
+}
+
+type PGStore struct {
+	pool *pgxpool.Pool
+}
+
+func NewPGStore(pool *pgxpool.Pool) *PGStore {
+	return &PGStore{pool: pool}
+}
+
+func (s *PGStore) ListChannelsForOwner(ctx context.Context, ownerID string) ([]NotificationChannel, error) {
+	var query string
+	var args []interface{}
+	if ownerID == "" {
+		query = `SELECT id, owner_id, COALESCE(bot_id, ''), channel_type, destination, enabled, created_at, updated_at
+			FROM notification_channels ORDER BY created_at DESC`
+	} else {
+		query = `SELECT id, owner_id, COALESCE(bot_id, ''), channel_type, destination, enabled, created_at, updated_at
+			FROM notification_channels WHERE owner_id = $1 ORDER BY created_at DESC`
+		args = append(args, ownerID)
+	}
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanChannels(rows)
+}
+
+func (s *PGStore) ListChannelsForBot(ctx context.Context, botID string) ([]NotificationChannel, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT nc.id, nc.owner_id, COALESCE(nc.bot_id, ''), nc.channel_type, nc.destination, nc.enabled, nc.created_at, nc.updated_at
+		FROM notification_channels nc
+		JOIN user_managers um ON um.manager_id = nc.owner_id
+		WHERE um.bot_id = $1
+		  AND nc.enabled = TRUE
+		  AND (nc.bot_id = $1 OR nc.bot_id IS NULL)
+	`, botID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanChannels(rows)
+}
+
+func (s *PGStore) GetChannel(ctx context.Context, id string) (*NotificationChannel, error) {
+	var ch NotificationChannel
+	err := s.pool.QueryRow(ctx, `
+		SELECT id, owner_id, COALESCE(bot_id, ''), channel_type, destination, enabled, created_at, updated_at
+		FROM notification_channels WHERE id = $1
+	`, id).Scan(&ch.ID, &ch.OwnerID, &ch.BotID, &ch.ChannelType, &ch.Destination, &ch.Enabled, &ch.CreatedAt, &ch.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &ch, nil
+}
+
+func (s *PGStore) CreateChannel(ctx context.Context, ch *NotificationChannel) error {
+	ch.ID = db.NewID("notch")
+	var botID *string
+	if ch.BotID != "" {
+		botID = &ch.BotID
+	}
+	return s.pool.QueryRow(ctx, `
+		INSERT INTO notification_channels(id, owner_id, bot_id, channel_type, destination)
+		VALUES($1, $2, $3, $4, $5)
+		RETURNING created_at, updated_at
+	`, ch.ID, ch.OwnerID, botID, ch.ChannelType, ch.Destination).Scan(&ch.CreatedAt, &ch.UpdatedAt)
+}
+
+func (s *PGStore) UpdateChannel(ctx context.Context, id string, channelType, destination string, enabled bool) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE notification_channels
+		SET channel_type = $2, destination = $3, enabled = $4, updated_at = NOW()
+		WHERE id = $1
+	`, id, channelType, destination, enabled)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *PGStore) DeleteChannel(ctx context.Context, id string) error {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM notification_channels WHERE id = $1`, id)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *PGStore) CheckCooldown(ctx context.Context, botID, pattern string) (bool, error) {
+	var exists bool
+	err := s.pool.QueryRow(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM denial_notifications
+			WHERE bot_id = $1 AND url_pattern = $2 AND cooldown_until > NOW()
+		)
+	`, botID, pattern).Scan(&exists)
+	return exists, err
+}
+
+func (s *PGStore) RecordNotification(ctx context.Context, botID, method, pattern string, cooldownUntil time.Time) error {
+	id := db.NewID("dnot")
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO denial_notifications(id, bot_id, method, url_pattern, cooldown_until)
+		VALUES($1, $2, $3, $4, $5)
+		ON CONFLICT(bot_id, url_pattern) DO UPDATE
+		SET notified_at = NOW(), method = EXCLUDED.method, cooldown_until = EXCLUDED.cooldown_until
+	`, id, botID, method, pattern, cooldownUntil)
+	return err
+}
+
+func scanChannels(rows interface {
+	Next() bool
+	Scan(dest ...interface{}) error
+	Close()
+	Err() error
+}) ([]NotificationChannel, error) {
+	var result []NotificationChannel
+	for rows.Next() {
+		var ch NotificationChannel
+		if err := rows.Scan(&ch.ID, &ch.OwnerID, &ch.BotID, &ch.ChannelType, &ch.Destination, &ch.Enabled, &ch.CreatedAt, &ch.UpdatedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, ch)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if result == nil {
+		result = []NotificationChannel{}
+	}
+	return result, nil
+}
+
+var ErrNotFound = fmt.Errorf("not found")
+
+// ListRecentDenials returns denials grouped by bot_id that haven't been digested yet.
+func (s *PGStore) ListRecentDenials(ctx context.Context) (map[string][]DenialInfo, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT bot_id, method, url_pattern FROM denial_notifications
+		WHERE digested_at IS NULL OR notified_at > digested_at
+		ORDER BY bot_id, notified_at DESC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[string][]DenialInfo)
+	for rows.Next() {
+		var botID, method, pattern string
+		if err := rows.Scan(&botID, &method, &pattern); err != nil {
+			return nil, err
+		}
+		result[botID] = append(result[botID], DenialInfo{Method: method, Pattern: pattern})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// MarkDigested marks all denial_notifications for a bot as included in a digest.
+func (s *PGStore) MarkDigested(ctx context.Context, botID string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE denial_notifications SET digested_at = NOW()
+		WHERE bot_id = $1 AND (digested_at IS NULL OR notified_at > digested_at)
+	`, botID)
+	return err
+}
+
+// ManagersForBot implements ManagerResolver by querying user_managers.
+func (s *PGStore) ManagersForBot(ctx context.Context, botID string) ([]string, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT manager_id FROM user_managers WHERE bot_id = $1
+	`, botID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}

--- a/internal/alerting/types.go
+++ b/internal/alerting/types.go
@@ -1,0 +1,8 @@
+package alerting
+
+// DenialInfo holds the details of a single denial.
+type DenialInfo struct {
+	Method  string
+	Pattern string
+	Reason  string
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,7 @@ type Config struct {
 	LLMJudge      LLMJudgeConfig      `yaml:"llm_judge"`
 	Admin         AdminConfig         `yaml:"admin"`
 	Observability ObservabilityConfig `yaml:"observability"`
+	Alerting      AlertingConfig      `yaml:"alerting"`
 }
 
 // ProxyConfig contains proxy server settings
@@ -113,6 +114,19 @@ type LLMJudgeConfig struct {
 type AuditConfig struct {
 	Output string `yaml:"output"`
 	Format string `yaml:"format"`
+}
+
+// AlertingConfig controls the denial alerting system.
+type AlertingConfig struct {
+	Enabled        bool          `yaml:"enabled"`
+	Cooldown       time.Duration `yaml:"cooldown"`        // dedup window per (bot, pattern); default 1h
+	DigestInterval time.Duration `yaml:"digest_interval"` // how often to send LLM summaries; default 1h
+	Slack          SlackConfig   `yaml:"slack"`
+}
+
+// SlackConfig holds the Slack bot token used by the SlackSender.
+type SlackConfig struct {
+	BotToken string `yaml:"bot_token"`
 }
 
 // Load reads and parses the configuration file. If the file does not exist,

--- a/internal/db/migrations/004_notification_channels.sql
+++ b/internal/db/migrations/004_notification_channels.sql
@@ -1,0 +1,30 @@
+-- Notification channels: destinations where managers receive denial alerts.
+-- Extensible via channel_type (slack, webhook, email, etc.).
+
+CREATE TABLE IF NOT EXISTS notification_channels (
+    id           TEXT PRIMARY KEY,
+    owner_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    bot_id       TEXT REFERENCES users(id) ON DELETE CASCADE,
+    channel_type TEXT NOT NULL,
+    destination  TEXT NOT NULL,
+    enabled      BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_channels_owner ON notification_channels(owner_id);
+CREATE INDEX IF NOT EXISTS idx_notification_channels_bot ON notification_channels(bot_id) WHERE bot_id IS NOT NULL;
+
+-- Tracks which (bot, url_pattern) pairs have been notified recently for dedup.
+CREATE TABLE IF NOT EXISTS denial_notifications (
+    id             TEXT PRIMARY KEY,
+    bot_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    method         TEXT NOT NULL DEFAULT '',
+    url_pattern    TEXT NOT NULL,
+    notified_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    cooldown_until TIMESTAMPTZ NOT NULL,
+    digested_at    TIMESTAMPTZ,
+    UNIQUE(bot_id, url_pattern)
+);
+
+CREATE INDEX IF NOT EXISTS idx_denial_notifications_bot ON denial_notifications(bot_id);

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,6 +1,6 @@
 import type {
   AuditEntry, LLMPolicy, PolicyStats,
-  UserSummary, UserDetail, ManagerAssignment,
+  UserSummary, UserDetail, ManagerAssignment, NotificationChannel,
   CreateUserRequest, UpdateUserRequest,
   EvalRun, EvalResult, AuditLabel, LLMResponse, StaticRule, ChatMessage,
 } from '../types'
@@ -215,6 +215,34 @@ export async function unassignManager(botId: string, managerId: string): Promise
 
 export async function getManagedBots(): Promise<UserSummary[]> {
   return fetchAPI<UserSummary[]>('/me/bots')
+}
+
+// ---- Notification Channels API ----
+
+export async function getNotificationChannels(): Promise<NotificationChannel[]> {
+  return fetchAPI<NotificationChannel[]>('/notification-channels')
+}
+
+export async function createNotificationChannel(req: { bot_id?: string; channel_type: string; destination: string }): Promise<NotificationChannel> {
+  return fetchAPI<NotificationChannel>('/notification-channels', {
+    method: 'POST',
+    body: JSON.stringify(req),
+  })
+}
+
+export async function updateNotificationChannel(id: string, req: { channel_type?: string; destination?: string; enabled?: boolean }): Promise<NotificationChannel> {
+  return fetchAPI<NotificationChannel>(`/notification-channels/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(req),
+  })
+}
+
+export async function deleteNotificationChannel(id: string): Promise<void> {
+  await fetchAPI(`/notification-channels/${id}`, { method: 'DELETE' })
+}
+
+export async function testNotificationChannel(id: string): Promise<void> {
+  await fetchAPI(`/notification-channels/${id}/test`, { method: 'POST' })
 }
 
 // ---- Eval API ----

--- a/web/src/components/UsersPanel.tsx
+++ b/web/src/components/UsersPanel.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useUsers } from '../hooks/useUsers'
 import { useAuth } from '../contexts/AuthContext'
-import { getPolicies, assignManager, unassignManager } from '../api/client'
+import { getPolicies, assignManager, unassignManager, getNotificationChannels, createNotificationChannel, deleteNotificationChannel, updateNotificationChannel, testNotificationChannel } from '../api/client'
 import type {
-  LLMPolicy, UserChannelInfo, UserDetail, ManagerAssignment,
+  LLMPolicy, UserChannelInfo, UserDetail, ManagerAssignment, NotificationChannel,
   CreateUserRequest, UpdateUserRequest,
 } from '../types'
 
@@ -405,6 +405,147 @@ function ManagersSection({ managers, botId, allUsers, onAssign, onUnassign }: {
   )
 }
 
+// ---- Notification Channels section ----
+
+function NotificationChannelsSection({ botId, onRefresh }: {
+  botId: string
+  onRefresh?: () => void
+}) {
+  const [channels, setChannels] = useState<NotificationChannel[]>([])
+  const [adding, setAdding] = useState(false)
+  const [channelType, setChannelType] = useState('slack')
+  const [destination, setDestination] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [testingId, setTestingId] = useState<string | null>(null)
+
+  useEffect(() => {
+    getNotificationChannels().then((all) => {
+      setChannels(all.filter((ch) => ch.bot_id === botId))
+    }).catch((err) => {
+      setError(err instanceof Error ? err.message : 'Failed to load notification channels')
+    })
+  }, [botId])
+
+  const handleAdd = async () => {
+    if (!destination) return
+    setBusy(true)
+    setError(null)
+    try {
+      const ch = await createNotificationChannel({ bot_id: botId, channel_type: channelType, destination })
+      setChannels((prev) => [ch, ...prev])
+      setDestination('')
+      setAdding(false)
+      onRefresh?.()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create channel')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Remove this notification channel?')) return
+    setError(null)
+    try {
+      await deleteNotificationChannel(id)
+      setChannels((prev) => prev.filter((ch) => ch.id !== id))
+      onRefresh?.()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete channel')
+    }
+  }
+
+  const handleToggle = async (ch: NotificationChannel) => {
+    try {
+      const updated = await updateNotificationChannel(ch.id, { enabled: !ch.enabled })
+      setChannels((prev) => prev.map((c) => c.id === ch.id ? updated : c))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update channel')
+    }
+  }
+
+  const handleTest = async (id: string) => {
+    setTestingId(id)
+    setError(null)
+    try {
+      await testNotificationChannel(id)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Test send failed')
+    } finally {
+      setTestingId(null)
+    }
+  }
+
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-base font-semibold text-gray-800">Notification Channels</h3>
+        {!adding && (
+          <button onClick={() => setAdding(true)} className={btnSecondary + ' text-xs'}>
+            Add Channel
+          </button>
+        )}
+      </div>
+      {error && <p className="text-red-600 text-sm mb-2">{error}</p>}
+      <div className="bg-white rounded-xl border border-gray-200 divide-y divide-gray-100">
+        {channels.length === 0 && !adding && (
+          <div className="px-4 py-3 text-sm text-gray-400">No notification channels configured</div>
+        )}
+        {channels.map((ch) => (
+          <div key={ch.id} className="px-4 py-3 flex items-center gap-3 text-sm">
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+              {ch.channel_type}
+            </span>
+            <span className="flex-1 font-mono text-gray-700">{ch.destination}</span>
+            <button
+              onClick={() => handleToggle(ch)}
+              className={`text-xs ${ch.enabled ? 'text-green-600' : 'text-gray-400'}`}
+            >
+              {ch.enabled ? 'Enabled' : 'Disabled'}
+            </button>
+            <button
+              onClick={() => handleTest(ch.id)}
+              disabled={testingId === ch.id}
+              className="text-xs text-blue-600 hover:underline disabled:opacity-50"
+            >
+              {testingId === ch.id ? 'Sending...' : 'Test'}
+            </button>
+            <button onClick={() => handleDelete(ch.id)} className="text-xs text-red-600 hover:underline">
+              Remove
+            </button>
+          </div>
+        ))}
+        {adding && (
+          <div className="px-4 py-3 flex items-center gap-2">
+            <select
+              value={channelType}
+              onChange={(e) => setChannelType(e.target.value)}
+              className="px-2 py-1 border border-gray-300 rounded text-sm"
+            >
+              <option value="slack">Slack</option>
+              <option value="webhook">Webhook</option>
+            </select>
+            <input
+              type="text"
+              value={destination}
+              onChange={(e) => setDestination(e.target.value)}
+              placeholder={channelType === 'slack' ? '#channel-name' : 'https://...'}
+              className="flex-1 px-2 py-1 border border-gray-300 rounded text-sm"
+            />
+            <button onClick={handleAdd} disabled={!destination || busy} className={btnSecondary + ' text-xs'}>
+              {busy ? 'Adding...' : 'Add'}
+            </button>
+            <button onClick={() => { setAdding(false); setDestination('') }} className="text-xs text-gray-500 hover:underline">
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
 // ---- Detail view ----
 
 export function UserDetailView({
@@ -498,6 +639,11 @@ export function UserDetailView({
           onAssign={handleAssignManager}
           onUnassign={handleUnassignManager}
         />
+      )}
+
+      {/* Notification Channels (only for bot users) */}
+      {user.role === 'user' && (
+        <NotificationChannelsSection botId={user.id} onRefresh={onRefreshUser} />
       )}
 
       {showEdit && (

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -148,6 +148,17 @@ export interface ManagerAssignment {
   created_at: string
 }
 
+export interface NotificationChannel {
+  id: string
+  owner_id: string
+  bot_id: string
+  channel_type: string
+  destination: string
+  enabled: boolean
+  created_at: string
+  updated_at: string
+}
+
 export interface UserDetail extends Omit<UserSummary, 'channel_count' | 'llm_policy_id'> {
   llm_policy_id?: string
   updated_at: string


### PR DESCRIPTION
## Summary (PR 1 of 3)

Adds the infrastructure for configuring notification channels — where managers receive alerts about their bots. No alerting dispatch logic yet (that's PR 2).

### What's included

- **Migration 004**: `notification_channels` table (owner_id, bot_id, channel_type, destination, enabled) + `denial_notifications` table for dedup tracking
- **`internal/alerting/` package**: Store interface + PGStore, Sender interface + SlackSender, minimal Service (sender registry only)
- **Admin API**: `GET/POST/PUT/DELETE /admin/notification-channels`, `POST .../test`
- **Frontend**: NotificationChannelsSection on bot detail page (add, remove, toggle, test-send)
- **Config**: `alerting.enabled`, `alerting.cooldown`, `alerting.slack.bot_token`

### Auth

- Managers can CRUD channels for bots they manage
- Admins can CRUD any channel
- `channel_type` validated against registered senders on create and update

### Stack

```
→ PR 1: Notification channels (this PR)
  PR 2: Denial alerting (dispatch logic)
  PR 3: LLM periodic digest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)