### PR TITLE
feat: periodic LLM denial digest (3/3)

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -141,6 +141,9 @@ func main() {
 		}
 		alertStore = alerting.NewPGStore(pool)
 		alertService = alerting.NewService(alertStore, alertStore, cooldown)
+		if cfg.Alerting.DigestInterval > 0 {
+			alertService.SetDigestInterval(cfg.Alerting.DigestInterval)
+		}
 		if token := envutil.Expand(cfg.Alerting.Slack.BotToken); token != "" {
 			alertService.RegisterSender("slack", alerting.NewSlackSender(token))
 		}
@@ -188,6 +191,9 @@ func main() {
 				"fast_model", cfg.LLMJudge.FastModel,
 				"thinking_model", cfg.LLMJudge.ThinkingModel,
 			)
+		}
+		if fastAdapter != nil && alertService != nil {
+			alertService.SetSummarizer(alerting.NewLLMSummarizer(fastAdapter))
 		}
 	}
 

--- a/internal/alerting/alerting.go
+++ b/internal/alerting/alerting.go
@@ -15,6 +15,11 @@ type ManagerResolver interface {
 	ManagersForBot(ctx context.Context, botID string) ([]string, error)
 }
 
+// Summarizer generates a periodic digest of what a bot was trying to do.
+type Summarizer interface {
+	Summarize(ctx context.Context, botID string, denials []DenialInfo) (string, error)
+}
+
 // DenialInfo holds the details of a single denial.
 type DenialInfo struct {
 	Method  string
@@ -26,24 +31,27 @@ type DenialInfo struct {
 // to managers' configured notification channels. Each new denied pattern
 // triggers an immediate notification; same pattern within cooldown is silent.
 type Service struct {
-	store    Store
-	resolver ManagerResolver
-	senders  map[string]Sender
-	cooldown time.Duration
-	dedup    map[string]time.Time // "botID\x00pattern" → cooldown_until
-	dedupMu  sync.RWMutex
-	stopOnce sync.Once
-	stopCh   chan struct{}
+	store          Store
+	resolver       ManagerResolver
+	senders        map[string]Sender
+	summarizer     Summarizer
+	cooldown       time.Duration
+	digestInterval time.Duration
+	dedup          map[string]time.Time // "botID\x00pattern" → cooldown_until
+	dedupMu        sync.RWMutex
+	stopOnce       sync.Once
+	stopCh         chan struct{}
 }
 
 func NewService(store Store, resolver ManagerResolver, cooldown time.Duration) *Service {
 	s := &Service{
-		store:    store,
-		resolver: resolver,
-		senders:  make(map[string]Sender),
-		cooldown: cooldown,
-		dedup:    make(map[string]time.Time),
-		stopCh:   make(chan struct{}),
+		store:          store,
+		resolver:       resolver,
+		senders:        make(map[string]Sender),
+		cooldown:       cooldown,
+		digestInterval: time.Hour,
+		dedup:          make(map[string]time.Time),
+		stopCh:         make(chan struct{}),
 	}
 	go s.cleanupLoop()
 	return s
@@ -55,6 +63,24 @@ func (s *Service) RegisterSender(channelType string, sender Sender) {
 
 func (s *Service) SenderFor(channelType string) Sender {
 	return s.senders[channelType]
+}
+
+// SetSummarizer configures the LLM summarizer and starts the digest loop.
+// Must be called from a single goroutine (typically during startup, after
+// SetDigestInterval if a custom interval is desired).
+func (s *Service) SetSummarizer(sum Summarizer) {
+	if s.summarizer == nil && sum != nil {
+		s.summarizer = sum
+		go s.digestLoop()
+	} else {
+		s.summarizer = sum
+	}
+}
+
+// SetDigestInterval sets the digest frequency. Must be called before
+// SetSummarizer to take effect.
+func (s *Service) SetDigestInterval(d time.Duration) {
+	s.digestInterval = d
 }
 
 func (s *Service) Stop() {
@@ -98,7 +124,6 @@ func (s *Service) dispatch(botID, pattern, key, method, reason string) {
 	inCooldown, err := s.store.CheckCooldown(ctx, botID, pattern)
 	if err != nil {
 		slog.Error("alerting: check cooldown", "error", err, "bot_id", botID, "pattern", pattern)
-		s.clearCooldown(key)
 		return
 	}
 	if inCooldown {
@@ -109,7 +134,6 @@ func (s *Service) dispatch(botID, pattern, key, method, reason string) {
 	cooldownUntil := time.Now().Add(s.cooldown)
 	if err := s.store.RecordNotification(ctx, botID, method, pattern, cooldownUntil); err != nil {
 		slog.Error("alerting: record notification", "error", err, "bot_id", botID, "pattern", pattern)
-		s.clearCooldown(key)
 		return
 	}
 	s.setCooldown(key, cooldownUntil)
@@ -166,10 +190,94 @@ func (s *Service) setCooldown(key string, until time.Time) {
 	s.dedup[key] = until
 }
 
-func (s *Service) clearCooldown(key string) {
-	s.dedupMu.Lock()
-	defer s.dedupMu.Unlock()
-	delete(s.dedup, key)
+// digestLoop runs periodically to send LLM-summarized digests of recent denials.
+func (s *Service) digestLoop() {
+	ticker := time.NewTicker(s.digestInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case <-ticker.C:
+			s.sendDigests()
+		}
+	}
+}
+
+func (s *Service) sendDigests() {
+	listCtx, listCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	botDenials, err := s.store.ListRecentDenials(listCtx)
+	listCancel()
+	if err != nil {
+		slog.Error("alerting: list recent denials for digest", "error", err)
+		return
+	}
+
+	for botID, denials := range botDenials {
+		if len(denials) == 0 {
+			continue
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
+		summary, err := s.summarizer.Summarize(ctx, botID, denials)
+		if err != nil {
+			slog.Error("alerting: summarize failed", "error", err, "bot_id", botID)
+			cancel()
+			continue
+		}
+		if summary == "" {
+			cancel()
+			continue
+		}
+
+		managerIDs, err := s.resolver.ManagersForBot(ctx, botID)
+		if err != nil {
+			cancel()
+			continue
+		}
+
+		channels, err := s.store.ListChannelsForBot(ctx, botID)
+		if err != nil {
+			cancel()
+			continue
+		}
+
+		managerSet := make(map[string]bool, len(managerIDs))
+		for _, id := range managerIDs {
+			managerSet[id] = true
+		}
+
+		msg := Message{
+			BotID:   botID,
+			Denials: denials,
+			Summary: summary,
+		}
+
+		anySent := false
+		for _, ch := range channels {
+			if !managerSet[ch.OwnerID] {
+				continue
+			}
+			sender, ok := s.senders[ch.ChannelType]
+			if !ok {
+				continue
+			}
+			if err := sender.Send(ctx, ch.Destination, msg); err != nil {
+				slog.Error("alerting: digest send failed", "error", err, "channel_id", ch.ID)
+			} else {
+				anySent = true
+			}
+		}
+
+		if anySent {
+			if err := s.store.MarkDigested(ctx, botID); err != nil {
+				slog.Error("alerting: mark digested", "error", err, "bot_id", botID)
+			}
+		}
+
+		cancel()
+	}
 }
 
 func (s *Service) cleanupLoop() {

--- a/internal/alerting/summarizer.go
+++ b/internal/alerting/summarizer.go
@@ -1,0 +1,53 @@
+package alerting
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/brexhq/CrabTrap/internal/llm"
+)
+
+// LLMSummarizer uses an LLM to generate a human-readable summary of what a bot
+// was trying to do when it was denied. Accepts a batch of denials so it can
+// identify multi-request operations. Returns empty string on any error.
+type LLMSummarizer struct {
+	adapter llm.Adapter
+}
+
+func NewLLMSummarizer(adapter llm.Adapter) *LLMSummarizer {
+	return &LLMSummarizer{adapter: adapter}
+}
+
+func (s *LLMSummarizer) Summarize(ctx context.Context, botID string, denials []DenialInfo) (string, error) {
+	if s.adapter == nil || len(denials) == 0 {
+		return "", nil
+	}
+
+	var lines []string
+	for _, d := range denials {
+		line := fmt.Sprintf("- %s %s", d.Method, d.Pattern)
+		if d.Reason != "" {
+			line += fmt.Sprintf(" (reason: %s)", d.Reason)
+		}
+		lines = append(lines, line)
+	}
+
+	prompt := fmt.Sprintf(
+		"A bot (%s) made HTTP requests that were denied by a security policy:\n\n%s\n\n"+
+			"In 1-2 sentences, explain what the bot was likely trying to do as a whole and why it was blocked. "+
+			"Be specific and actionable — a manager will read this to decide whether to update the policy.",
+		botID, strings.Join(lines, "\n"),
+	)
+
+	resp, err := s.adapter.Complete(ctx, llm.Request{
+		System:    "You summarize AI agent denial events concisely for engineering managers.",
+		Messages:  []llm.Message{{Role: "user", Content: prompt}},
+		MaxTokens: 150,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(resp.Text), nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,9 +118,10 @@ type AuditConfig struct {
 
 // AlertingConfig controls the denial alerting system.
 type AlertingConfig struct {
-	Enabled  bool          `yaml:"enabled"`
-	Cooldown time.Duration `yaml:"cooldown"` // dedup window per (bot, pattern); default 1h
-	Slack    SlackConfig   `yaml:"slack"`
+	Enabled        bool          `yaml:"enabled"`
+	Cooldown       time.Duration `yaml:"cooldown"`        // dedup window per (bot, pattern); default 1h
+	DigestInterval time.Duration `yaml:"digest_interval"` // how often to send LLM summaries; default 1h
+	Slack          SlackConfig   `yaml:"slack"`
 }
 
 // SlackConfig holds the Slack bot token used by the SlackSender.


### PR DESCRIPTION
## Summary (PR 3 of 3 — stacked on #22)

Adds an optional periodic digest that uses the LLM to summarize all recent denials per bot into an actionable overview for managers.

### What's included

- **`internal/alerting/summarizer.go`**: `LLMSummarizer` implementation using the fast LLM adapter
- **Digest loop** in `alerting.go`: runs on configurable interval (default 1h), queries un-digested denials, generates LLM summary, sends one digest message per bot
- **Dedup**: marks patterns as `digested_at` after send; only includes patterns where `notified_at > digested_at`
- **Config**: `alerting.digest_interval`
- **Wiring**: connects summarizer to fast LLM adapter in main.go

### Behavior

- No new denials since last digest → no message sent
- Same patterns keep repeating → appear in ONE digest, then silent
- All sends fail (Slack outage) → patterns NOT marked digested, retried next cycle
- Per-bot 30s context prevents one slow bot from blocking others

### Slack digest format

> :bar_chart: **Denial digest** for `bot-a@company.com`
>
> The bot attempted to deploy code via the GitHub Repos API and notify the team via Slack. The current policy blocks write access to both services.
>
> Patterns blocked:
> • `api.github.com/repos/org`
> • `slack.com/api/chat.postMessage`

### Stack

```
  PR 1: Notification channels (#21)
  PR 2: Denial alerting (#22)
→ PR 3: LLM periodic digest (this PR)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)