### PR TITLE
fix(alerting): channel lookup should not require owner to be a manager

### DIFF
--- a/internal/alerting/alerting.go
+++ b/internal/alerting/alerting.go
@@ -160,24 +160,13 @@ func (s *Service) tryFlush() {
 }
 
 func (s *Service) flushBot(ctx context.Context, botID string, denials []DenialInfo) {
-	managerIDs, err := s.resolver.ManagersForBot(ctx, botID)
-	if err != nil {
-		slog.Error("alerting: resolve managers", "error", err, "bot_id", botID)
-		return
-	}
-	if len(managerIDs) == 0 {
-		slog.Debug("alerting: no managers, deleting buffer", "bot_id", botID, "count", len(denials))
-		s.deleteFlushed(ctx, denials)
-		return
-	}
-
 	channels, err := s.store.ListActiveChannelsForBot(ctx, botID)
 	if err != nil {
 		slog.Error("alerting: list channels", "error", err, "bot_id", botID)
 		return
 	}
 	if len(channels) == 0 {
-		slog.Debug("alerting: no channels, deleting buffer", "bot_id", botID, "count", len(denials))
+		slog.Warn("alerting: no channels configured for bot, denials dropped", "bot_id", botID, "count", len(denials))
 		s.deleteFlushed(ctx, denials)
 		return
 	}
@@ -191,11 +180,6 @@ func (s *Service) flushBot(ctx context.Context, botID string, denials []DenialIn
 		summary = fmt.Sprintf("%d requests were denied. LLM summary unavailable.", len(denials))
 	}
 
-	managerSet := make(map[string]bool, len(managerIDs))
-	for _, id := range managerIDs {
-		managerSet[id] = true
-	}
-
 	msg := Message{
 		BotID:   botID,
 		Denials: denials,
@@ -203,9 +187,6 @@ func (s *Service) flushBot(ctx context.Context, botID string, denials []DenialIn
 	}
 
 	for _, ch := range channels {
-		if !managerSet[ch.OwnerID] {
-			continue
-		}
 		sender := s.SenderFor(ch.ChannelType)
 		if sender == nil {
 			continue

--- a/internal/alerting/store.go
+++ b/internal/alerting/store.go
@@ -78,14 +78,11 @@ func (s *PGStore) ListChannelsForBot(ctx context.Context, botID string) ([]Notif
 
 func (s *PGStore) ListActiveChannelsForBot(ctx context.Context, botID string) ([]NotificationChannel, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT DISTINCT ON (nc.owner_id, nc.channel_type, nc.destination)
-			nc.id, nc.owner_id, COALESCE(nc.bot_id, ''), nc.channel_type, nc.destination, nc.enabled, nc.created_at, nc.updated_at
+		SELECT nc.id, nc.owner_id, COALESCE(nc.bot_id, ''), nc.channel_type, nc.destination, nc.enabled, nc.created_at, nc.updated_at
 		FROM notification_channels nc
-		JOIN user_managers um ON um.manager_id = nc.owner_id
-		WHERE um.bot_id = $1
+		WHERE nc.bot_id = $1
 		  AND nc.enabled = TRUE
-		  AND (nc.bot_id = $1 OR nc.bot_id IS NULL)
-		ORDER BY nc.owner_id, nc.channel_type, nc.destination, nc.bot_id NULLS LAST
+		ORDER BY nc.created_at DESC
 	`, botID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

Notification channels only triggered alerts if the channel owner was a manager of the bot. An admin creating a channel for a bot silently produced no notifications.

## Root Cause

Two layers of manager filtering:
1. `ListActiveChannelsForBot` SQL query joined `user_managers` — only returned channels owned by managers
2. `flushBot` Go code filtered channels by `managerSet[ch.OwnerID]` — skipped channels whose owner wasn't a manager

## Fix

Removed both filters. A channel attached to a bot (`bot_id = $1 AND enabled = TRUE`) is used for alerting regardless of who created it.

## Verified

Tested in production: admin-created channel now triggers Slack notification.