### PR TITLE
fix(alerting): batch all denials per bot together + atomic flush

### DIFF
--- a/internal/admin/notification_integration_test.go
+++ b/internal/admin/notification_integration_test.go
@@ -288,6 +288,43 @@ func TestDenialAlert_SamePatternDeduped(t *testing.T) {
 	}
 }
 
+func TestClaimFlushableDenials_SecondCallEmpty(t *testing.T) {
+	if testPool == nil {
+		t.Skip("no test database")
+	}
+	truncateTables(t)
+
+	alertStore := alerting.NewPGStore(testPool)
+	ctx := context.Background()
+
+	// Buffer several denials for the same bot
+	for i := 0; i < 3; i++ {
+		err := alertStore.BufferDenial(ctx, "bot@example.com", "POST",
+			fmt.Sprintf("https://api.github.com/repos/org/repo-%d", i), "policy blocked")
+		if err != nil {
+			t.Fatalf("buffer denial %d: %v", i, err)
+		}
+	}
+
+	// First claim should return all 3 denials
+	result, err := alertStore.ClaimFlushableDenials(ctx, 0)
+	if err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if len(result["bot@example.com"]) != 3 {
+		t.Fatalf("first claim: expected 3 denials, got %d", len(result["bot@example.com"]))
+	}
+
+	// Second claim should return empty — rows were atomically deleted
+	result, err = alertStore.ClaimFlushableDenials(ctx, 0)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("second claim: expected empty map, got %d bots with denials", len(result))
+	}
+}
+
 func TestDenialAlert_MultipleURLsBatched(t *testing.T) {
 	if testPool == nil {
 		t.Skip("no test database")

--- a/internal/admin/notification_integration_test.go
+++ b/internal/admin/notification_integration_test.go
@@ -295,7 +295,10 @@ func TestClaimFlushableDenials_SecondCallEmpty(t *testing.T) {
 	truncateTables(t)
 
 	alertStore := alerting.NewPGStore(testPool)
+	userStore := NewPGUserStore(testPool)
 	ctx := context.Background()
+
+	userStore.CreateUser(CreateUserRequest{ID: "bot@example.com"})
 
 	// Buffer several denials for the same bot
 	for i := 0; i < 3; i++ {

--- a/internal/alerting/alerting.go
+++ b/internal/alerting/alerting.go
@@ -138,19 +138,9 @@ func (s *Service) tryFlush() {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	locked, unlock, err := s.store.TryAdvisoryLock(ctx)
+	botDenials, err := s.store.ClaimFlushableDenials(ctx, s.batchWait)
 	if err != nil {
-		slog.Error("alerting: advisory lock", "error", err)
-		return
-	}
-	if !locked {
-		return
-	}
-	defer unlock()
-
-	botDenials, err := s.store.FlushableDenials(ctx, s.batchWait)
-	if err != nil {
-		slog.Error("alerting: query flushable denials", "error", err)
+		slog.Error("alerting: claim flushable denials", "error", err)
 		return
 	}
 
@@ -167,7 +157,6 @@ func (s *Service) flushBot(ctx context.Context, botID string, denials []DenialIn
 	}
 	if len(channels) == 0 {
 		slog.Warn("alerting: no channels configured for bot, denials dropped", "bot_id", botID, "count", len(denials))
-		s.deleteFlushed(ctx, denials)
 		return
 	}
 
@@ -199,19 +188,5 @@ func (s *Service) flushBot(ctx context.Context, botID string, denials []DenialIn
 		} else if s.metrics != nil {
 			s.metrics.RecordAlertNotificationSent(ctx, ch.ChannelType)
 		}
-	}
-
-	// Always delete after flush — even on send failure. Retrying broken sender
-	// config forever would fill the buffer. Errors are logged + metricked.
-	s.deleteFlushed(ctx, denials)
-}
-
-func (s *Service) deleteFlushed(ctx context.Context, denials []DenialInfo) {
-	ids := make([]string, len(denials))
-	for i, d := range denials {
-		ids[i] = d.ID
-	}
-	if err := s.store.DeleteBufferedDenials(ctx, ids); err != nil {
-		slog.Error("alerting: delete flushed", "error", err)
 	}
 }

--- a/internal/alerting/alerting.go
+++ b/internal/alerting/alerting.go
@@ -38,8 +38,8 @@ type MetricsObserver interface {
 
 // Service implements notifications.Channel and dispatches batched denial
 // alerts. Denials are buffered in PostgreSQL for multi-replica safety.
-// A background ticker periodically flushes buffered denials using a
-// pg_advisory_lock to ensure only one replica sends at a time.
+// A background ticker periodically flushes buffered denials using an
+// atomic DELETE ... FOR UPDATE to ensure each denial is processed exactly once.
 type Service struct {
 	store      Store
 	resolver   ManagerResolver

--- a/internal/alerting/store.go
+++ b/internal/alerting/store.go
@@ -30,9 +30,7 @@ type Store interface {
 	UpdateChannel(ctx context.Context, id string, channelType, destination string, enabled bool) error
 	DeleteChannel(ctx context.Context, id string) error
 	BufferDenial(ctx context.Context, botID, method, url, reason string) error
-	FlushableDenials(ctx context.Context, batchWait time.Duration) (map[string][]DenialInfo, error)
-	DeleteBufferedDenials(ctx context.Context, ids []string) error
-	TryAdvisoryLock(ctx context.Context) (locked bool, unlock func(), err error)
+	ClaimFlushableDenials(ctx context.Context, batchWait time.Duration) (map[string][]DenialInfo, error)
 }
 
 type PGStore struct {
@@ -190,8 +188,6 @@ func (s *PGStore) ManagersForBot(ctx context.Context, botID string) ([]string, e
 	return ids, nil
 }
 
-const advisoryLockID = 7283947 // arbitrary unique lock ID for denial alerting
-
 func (s *PGStore) BufferDenial(ctx context.Context, botID, method, url, reason string) error {
 	id := db.NewID("dbuf")
 	_, err := s.pool.Exec(ctx, `
@@ -201,12 +197,21 @@ func (s *PGStore) BufferDenial(ctx context.Context, botID, method, url, reason s
 	return err
 }
 
-func (s *PGStore) FlushableDenials(ctx context.Context, batchWait time.Duration) (map[string][]DenialInfo, error) {
+func (s *PGStore) ClaimFlushableDenials(ctx context.Context, batchWait time.Duration) (map[string][]DenialInfo, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT id, bot_id, method, url, reason FROM denial_buffer
-		WHERE created_at < NOW() - make_interval(secs => $1)
-		ORDER BY bot_id, created_at
-		LIMIT 1000
+		WITH ready_bots AS (
+			SELECT bot_id FROM denial_buffer
+			GROUP BY bot_id
+			HAVING MIN(created_at) < NOW() - make_interval(secs => $1)
+		)
+		DELETE FROM denial_buffer
+		WHERE id IN (
+			SELECT db.id FROM denial_buffer db
+			JOIN ready_bots rb ON rb.bot_id = db.bot_id
+			LIMIT 1000
+			FOR UPDATE OF db
+		)
+		RETURNING id, bot_id, method, url, reason
 	`, int(batchWait.Seconds()))
 	if err != nil {
 		return nil, err
@@ -225,35 +230,4 @@ func (s *PGStore) FlushableDenials(ctx context.Context, batchWait time.Duration)
 		return nil, err
 	}
 	return result, nil
-}
-
-func (s *PGStore) DeleteBufferedDenials(ctx context.Context, ids []string) error {
-	if len(ids) == 0 {
-		return nil
-	}
-	_, err := s.pool.Exec(ctx, `DELETE FROM denial_buffer WHERE id = ANY($1)`, ids)
-	return err
-}
-
-func (s *PGStore) TryAdvisoryLock(ctx context.Context) (bool, func(), error) {
-	conn, err := s.pool.Acquire(ctx)
-	if err != nil {
-		return false, nil, err
-	}
-	var locked bool
-	err = conn.QueryRow(ctx, `SELECT pg_try_advisory_lock($1)`, advisoryLockID).Scan(&locked)
-	if err != nil {
-		conn.Release()
-		return false, nil, err
-	}
-	if !locked {
-		conn.Release()
-		return false, nil, nil
-	}
-	unlock := func() {
-		// Use background context — the parent ctx may be cancelled by the time we unlock.
-		conn.Exec(context.Background(), `SELECT pg_advisory_unlock($1)`, advisoryLockID) //nolint:errcheck
-		conn.Release()
-	}
-	return true, unlock, nil
 }


### PR DESCRIPTION
## Problem

Two quick requests to the same bot produced two separate Slack notifications instead of one batched notification. Each notification contained the full batch (both requests) — confirmed duplicate processing by multiple replicas.

**Root causes:**

1. **Per-row timestamp check:** The old query checks each row individually (`WHERE created_at < NOW() - 5min`). Requests arriving seconds apart cross the threshold at different 30-second ticks, producing split batches.

2. **Advisory lock broken through pgbouncer:** `pg_advisory_lock` doesn't persist across pooled connections in transaction mode. Multiple replicas independently flush the same rows.

## Fix

Single atomic query that solves both:

```sql
WITH ready_bots AS (
    SELECT bot_id FROM denial_buffer
    GROUP BY bot_id
    HAVING MIN(created_at) < NOW() - make_interval(secs => $1)
)
DELETE FROM denial_buffer
WHERE id IN (
    SELECT db.id FROM denial_buffer db
    JOIN ready_bots rb ON rb.bot_id = db.bot_id
    LIMIT 1000
    FOR UPDATE OF db
)
RETURNING id, bot_id, method, url, reason
```

- **Proper batching:** `HAVING MIN(created_at)` — once any denial for a bot is old enough, ALL of that bot's denials flush together
- **No duplicates:** `FOR UPDATE OF db` — second replica blocks until first completes the DELETE, then finds no rows
- **Bounded:** `LIMIT 1000` caps rows per cycle
- **Simpler:** Removes advisory lock, separate SELECT, separate DELETE

## Before/After

**Before:** 7 requests (1 + 3 nba + 3 nfl over 3 minutes) → 4 Slack messages (2 duplicate batches)

**After:** same scenario → 1 or 2 Slack messages (1 nba alone if it crosses threshold first, then 1 with all 6 together — or all 7 in one if they're within the same bot's window)