### PR TITLE
fix(lint): move test-only glob cache helpers to _test.go

### DIFF
--- a/internal/approval/glob_test_helpers_test.go
+++ b/internal/approval/glob_test_helpers_test.go
@@ -1,0 +1,16 @@
+package approval
+
+import "regexp"
+
+func globCacheLen() int {
+	globCache.RLock()
+	n := len(globCache.m)
+	globCache.RUnlock()
+	return n
+}
+
+func resetGlobCache() {
+	globCache.Lock()
+	globCache.m = make(map[string]*regexp.Regexp)
+	globCache.Unlock()
+}

--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -499,21 +499,6 @@ func globToRegexp(pattern string) (*regexp.Regexp, error) {
 	return re, nil
 }
 
-// globCacheLen returns the current number of entries in the glob regexp cache.
-// Exported for testing only.
-func globCacheLen() int {
-	globCache.RLock()
-	n := len(globCache.m)
-	globCache.RUnlock()
-	return n
-}
-
-// resetGlobCache clears the glob regexp cache. Exported for testing only.
-func resetGlobCache() {
-	globCache.Lock()
-	globCache.m = make(map[string]*regexp.Regexp)
-	globCache.Unlock()
-}
 
 // judgeResultToLLMResponse converts a JudgeResult to a types.LLMResponse.
 func judgeResultToLLMResponse(r judge.JudgeResult, err error) *types.LLMResponse {


### PR DESCRIPTION
## Summary
- Moves `globCacheLen` and `resetGlobCache` from `manager.go` to a new `glob_test_helpers_test.go` file
- Fixes staticcheck U1000 (unused function) lint errors — these functions are only called from tests
- No behavioral change; tests continue to pass

## Test plan
- [x] `go build ./internal/approval/` passes
- [x] `go vet ./internal/approval/` passes
- [x] `go test ./internal/approval/` passes
- [x] `staticcheck ./internal/approval/` no longer reports U1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)