### PR TITLE
fix(builder): paginate analyze_traffic and recover from context overflow

### DIFF
--- a/internal/admin/pg_audit_reader.go
+++ b/internal/admin/pg_audit_reader.go
@@ -555,7 +555,7 @@ func (r *PGAuditReader) AggregatePathGroups(
 		  AND channel != 'auto'
 		  AND timestamp >= $2 AND timestamp <= $3
 		  AND ($4 = '' OR substring(split_part(url, '?', 1) from '://([^/]+)') = $4)
-		  AND ($5 = '' OR regexp_replace(split_part(url, '?', 1), '^[a-z][a-z0-9+.-]*://[^/]+', '') LIKE $5 || '%')
+		  AND ($5 = '' OR starts_with(regexp_replace(split_part(url, '?', 1), '^[a-z][a-z0-9+.-]*://[^/]+', ''), $5))
 		GROUP BY method, path_pattern
 		ORDER BY cnt DESC
 		LIMIT 50000

--- a/internal/admin/pg_audit_reader.go
+++ b/internal/admin/pg_audit_reader.go
@@ -531,8 +531,11 @@ func (r *PGAuditReader) QueryBatched(ctx context.Context, filter AuditFilter, ba
 // AggregatePathGroups groups audit log entries by normalized path pattern across all channels.
 // SQL handles UUID and integer normalization; Go applies a second NormalizeURL pass
 // for hex and token patterns, then re-groups and returns all results sorted by count DESC.
+//
+// hostFilter (exact host match) and pathPrefix (URL path prefix match) optionally
+// narrow the scan before grouping; empty strings disable the respective filter.
 func (r *PGAuditReader) AggregatePathGroups(
-	userID string, start, end time.Time,
+	userID string, start, end time.Time, hostFilter, pathPrefix string,
 ) []builder.PathGroup {
 	ctx := context.Background()
 
@@ -551,10 +554,12 @@ func (r *PGAuditReader) AggregatePathGroups(
 		WHERE user_id = $1
 		  AND channel != 'auto'
 		  AND timestamp >= $2 AND timestamp <= $3
+		  AND ($4 = '' OR substring(split_part(url, '?', 1) from '://([^/]+)') = $4)
+		  AND ($5 = '' OR regexp_replace(split_part(url, '?', 1), '^[a-z][a-z0-9+.-]*://[^/]+', '') LIKE $5 || '%')
 		GROUP BY method, path_pattern
 		ORDER BY cnt DESC
 		LIMIT 50000
-	`, userID, start, end)
+	`, userID, start, end, hostFilter, pathPrefix)
 	if err != nil {
 		return nil
 	}

--- a/internal/admin/policies_integration_test.go
+++ b/internal/admin/policies_integration_test.go
@@ -368,7 +368,7 @@ func TestPublish_AlreadyPublished_Returns409(t *testing.T) {
 // stubTrafficReader satisfies builder.TrafficReader for testing without DB.
 type stubPoliciesTrafficReader struct{}
 
-func (r *stubPoliciesTrafficReader) AggregatePathGroups(_ string, _, _ time.Time) []builder.PathGroup {
+func (r *stubPoliciesTrafficReader) AggregatePathGroups(_ string, _, _ time.Time, _, _ string) []builder.PathGroup {
 	return nil
 }
 func (r *stubPoliciesTrafficReader) SampleRequestsForPath(_, _, _ string, _, _ time.Time, _ int) []builder.RequestSample {
@@ -784,10 +784,10 @@ func TestPublish_ImmutableAfterPublish(t *testing.T) {
 // stubPoliciesTrafficReaderWithData returns fixed groups and samples for E2E tests.
 type stubPoliciesTrafficReaderWithData struct{}
 
-func (r *stubPoliciesTrafficReaderWithData) AggregatePathGroups(_ string, _, _ time.Time) []builder.PathGroup {
+func (r *stubPoliciesTrafficReaderWithData) AggregatePathGroups(_ string, _, _ time.Time, _, _ string) []builder.PathGroup {
 	return []builder.PathGroup{
-		{Method: "GET", PathPattern: "/v1/applications/{id}", Count: 120},
-		{Method: "POST", PathPattern: "/v1/jobs/{id}/move", Count: 15},
+		{Method: "GET", PathPattern: "https://api.greenhouse.io/v1/applications/{id}", Count: 120},
+		{Method: "POST", PathPattern: "https://api.greenhouse.io/v1/jobs/{id}/move", Count: 15},
 	}
 }
 func (r *stubPoliciesTrafficReaderWithData) SampleRequestsForPath(_, _, _ string, _, _ time.Time, _ int) []builder.RequestSample {
@@ -809,8 +809,9 @@ func TestAgent_AnalyzeAndUpdateE2E(t *testing.T) {
 		callN++
 		switch callN {
 		case 1:
-			input, _ := json.Marshal(map[string]string{
+			input, _ := json.Marshal(map[string]interface{}{
 				"user_id": "alice", "start_date": "2024-01-01T00:00:00Z", "end_date": "2024-03-31T00:00:00Z",
+				"group_by": "endpoint", "summarize": true,
 			})
 			return llm.Response{StopReason: "tool_use", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "analyze_traffic", Input: input}}}, nil
 		case 2:

--- a/internal/builder/agent.go
+++ b/internal/builder/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -14,6 +15,20 @@ import (
 
 const maxAgentIterations = 10
 const agentConcurrency = 10
+
+// analyze_traffic pagination bounds. Every call returns at most maxAnalyzeLimit
+// rows regardless of what the agent asks for, so a single call can never explode
+// the agent's context window (the failure that otherwise surfaces as a generic
+// "network error"). The agent pages through results with limit/offset and drills
+// down with the host/path_prefix filters instead of receiving everything at once.
+const (
+	defaultAnalyzeLimit = 50  // page size when the agent does not specify one
+	maxAnalyzeLimit     = 100 // hard ceiling on rows (and, when summarizing, on fast-model calls) per call
+)
+
+// maxContextRecoveries bounds how many times the agent loop will shrink an
+// oversized tool result and retry after a context-length error before giving up.
+const maxContextRecoveries = 4
 
 // ---- Types ----
 
@@ -30,12 +45,14 @@ type RequestSample struct {
 	Body string
 }
 
-// EndpointSummary is the fast-model description of one endpoint group.
-type EndpointSummary struct {
-	Method      string
-	PathPattern string
-	Count       int
-	Description string
+// hostGroup is the request volume and distinct-endpoint count for one host,
+// derived from the path groups. Used by analyze_traffic's group_by="host" mode
+// to give the agent the breadth of egress destinations cheaply (no fast-model
+// calls), which is the natural starting point for authoring a per-domain policy.
+type hostGroup struct {
+	host          string
+	count         int // total requests to this host
+	endpointCount int // distinct (method, path pattern) groups on this host
 }
 
 // ChatMessage is an alias kept for backward compatibility within this package.
@@ -44,7 +61,11 @@ type ChatMessage = types.ChatMessage
 // TrafficReader fetches observed traffic for use by the analyze_traffic tool.
 // Implemented by *admin.PGAuditReader.
 type TrafficReader interface {
-	AggregatePathGroups(userID string, start, end time.Time) []PathGroup
+	// AggregatePathGroups returns every normalized (method, path pattern) group for
+	// the user in the window, sorted by request count descending. hostFilter and
+	// pathPrefix optionally narrow the scan: hostFilter matches a host exactly,
+	// pathPrefix matches the start of the URL path. Empty strings mean no filter.
+	AggregatePathGroups(userID string, start, end time.Time, hostFilter, pathPrefix string) []PathGroup
 	SampleRequestsForPath(userID, method, pathPrefix string, start, end time.Time, limit int) []RequestSample
 }
 
@@ -106,13 +127,26 @@ func (a *PolicyAgent) Run(
 	}
 
 	for i := 0; i < maxAgentIterations; i++ {
-		resp, err := a.thinkingAdapter.Complete(ctx, llm.Request{
-			System:    systemPrompt,
-			Messages:  messages,
-			Tools:     agentTools,
-			MaxTokens: 4096,
-		})
+		resp, err := a.completeWithContextRecovery(ctx, systemPrompt, messages, notify)
 		if err != nil {
+			// A context-length error that recovery could not resolve is reported back
+			// to the user as guidance rather than a fatal error, and the turn's
+			// (now-compacted) messages are preserved so the conversation can continue.
+			if isContextLengthError(err) {
+				msg := "I gathered more traffic detail than fits in my working context. " +
+					"Please narrow the request — use a shorter date range, focus on a specific " +
+					"domain (group_by=\"endpoint\" with a host filter), or ask for a high-level " +
+					"breakdown first (group_by=\"host\") — and I'll continue from there."
+				return AgentResult{
+					Message:       msg,
+					PolicyUpdated: state.policyUpdated,
+					PolicyPrompt:  state.currentPrompt,
+					StaticRules:   state.currentRules,
+					NewSummaries:  state.summaries,
+					NewName:       state.currentName,
+					NewMessages:   collectNewMessages(messages, userMsgIdx, msg),
+				}, nil
+			}
 			return AgentResult{}, fmt.Errorf("agent call failed: %w", err)
 		}
 
@@ -173,6 +207,97 @@ func (a *PolicyAgent) Run(
 	return AgentResult{}, fmt.Errorf("agent exceeded maximum iterations (%d)", maxAgentIterations)
 }
 
+// completeWithContextRecovery calls the thinking model and, if it fails because
+// the request exceeded the model's context window, shrinks the single largest
+// tool result in the conversation to a short notice and retries — up to
+// maxContextRecoveries times. The tool result is mutated in place (via its
+// pointer), so the compaction also persists into the messages the caller keeps.
+// Non-context errors, and context errors with nothing left to shrink, are
+// returned unchanged for the caller to handle.
+func (a *PolicyAgent) completeWithContextRecovery(
+	ctx context.Context, system string, messages []llm.Message, notify func(string, interface{}),
+) (llm.Response, error) {
+	for attempt := 0; ; attempt++ {
+		resp, err := a.thinkingAdapter.Complete(ctx, llm.Request{
+			System:    system,
+			Messages:  messages,
+			Tools:     agentTools,
+			MaxTokens: 4096,
+		})
+		if err == nil {
+			return resp, nil
+		}
+		if !isContextLengthError(err) || attempt >= maxContextRecoveries {
+			return llm.Response{}, err
+		}
+		if !compactLargestToolResult(messages) {
+			return llm.Response{}, err // nothing left to shrink
+		}
+		notify("context_recovery", map[string]interface{}{
+			"message": "Previous tool output exceeded the context window; discarded it and retrying.",
+			"attempt": attempt + 1,
+		})
+	}
+}
+
+// compactedResultNotice prefixes a tool result whose content we discarded to fit
+// the context window. The agent sees this in place of the original output.
+const compactedResultNotice = "[Tool output discarded: it was too large for the context window.]"
+
+// compactLargestToolResult replaces the content of the largest not-yet-compacted
+// tool result with a short notice and marks it as an error, so the model knows
+// the data is gone and can re-request it more narrowly. Returns false when there
+// is no further tool result worth shrinking.
+func compactLargestToolResult(messages []llm.Message) bool {
+	idx, maxLen := -1, 0
+	for i := range messages {
+		tr := messages[i].ToolResult
+		if tr == nil || strings.HasPrefix(tr.Content, compactedResultNotice) {
+			continue
+		}
+		if len(tr.Content) > maxLen {
+			idx, maxLen = i, len(tr.Content)
+		}
+	}
+	// Only bother if the candidate is large enough that shrinking it could matter.
+	if idx < 0 || maxLen < 1000 {
+		return false
+	}
+	messages[idx].ToolResult.Content = fmt.Sprintf(
+		"%s (~%d characters omitted). Re-run the tool with a narrower scope: add a host or "+
+			"path_prefix filter, set summarize=false, or use a smaller limit.",
+		compactedResultNotice, maxLen)
+	messages[idx].ToolResult.IsError = true
+	return true
+}
+
+// isContextLengthError reports whether err looks like a provider rejecting the
+// request because it exceeded the model's context window. It matches on message
+// text to stay provider-agnostic (Bedrock, direct Anthropic, and OpenAI all
+// surface this differently), tolerating the surrounding wrapping each adds.
+func isContextLengthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(s, "too long"): // "input is too long", "prompt is too long"
+		return true
+	case strings.Contains(s, "context length") || strings.Contains(s, "context window"):
+		return true
+	case strings.Contains(s, "maximum context"):
+		return true
+	case strings.Contains(s, "context_length_exceeded"):
+		return true
+	case strings.Contains(s, "too many tokens") || strings.Contains(s, "too many input tokens"):
+		return true
+	case strings.Contains(s, "token") && strings.Contains(s, "exceed"):
+		return true
+	default:
+		return false
+	}
+}
+
 type agentState struct {
 	currentName   string
 	currentPrompt string
@@ -198,9 +323,15 @@ func (a *PolicyAgent) executeTool(ctx context.Context, call llm.ToolCall, state 
 
 func (a *PolicyAgent) toolAnalyzeTraffic(ctx context.Context, input json.RawMessage, state *agentState, notify func(string, interface{})) (string, error) {
 	var params struct {
-		UserID    string `json:"user_id"`
-		StartDate string `json:"start_date"`
-		EndDate   string `json:"end_date"`
+		UserID     string `json:"user_id"`
+		StartDate  string `json:"start_date"`
+		EndDate    string `json:"end_date"`
+		GroupBy    string `json:"group_by"`
+		Host       string `json:"host"`
+		PathPrefix string `json:"path_prefix"`
+		Summarize  bool   `json:"summarize"`
+		Limit      *int   `json:"limit"`
+		Offset     int    `json:"offset"`
 	}
 	if err := json.Unmarshal(input, &params); err != nil {
 		return "", fmt.Errorf("invalid analyze_traffic input: %w", err)
@@ -215,62 +346,248 @@ func (a *PolicyAgent) toolAnalyzeTraffic(ctx context.Context, input json.RawMess
 		return "", fmt.Errorf("invalid end_date: %w", err)
 	}
 
-	groups := a.reader.AggregatePathGroups(params.UserID, start, end)
+	groupBy := params.GroupBy
+	if groupBy == "" {
+		groupBy = "host"
+	}
+	if groupBy != "host" && groupBy != "endpoint" {
+		return "", fmt.Errorf("invalid group_by %q: must be \"host\" or \"endpoint\"", params.GroupBy)
+	}
+
+	// Resolve the page size. A nil limit means "use the default"; an explicit 0
+	// means "counts only, no list"; anything else is clamped to [0, maxAnalyzeLimit]
+	// so a single call can never overflow the agent's context.
+	limit := defaultAnalyzeLimit
+	if params.Limit != nil {
+		limit = *params.Limit
+		switch {
+		case limit < 0:
+			limit = 0
+		case limit > maxAnalyzeLimit:
+			limit = maxAnalyzeLimit
+		}
+	}
+	offset := params.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	groups := a.reader.AggregatePathGroups(params.UserID, start, end, params.Host, params.PathPrefix)
 	if len(groups) == 0 {
-		return "No traffic found for this user in the specified date range.", nil
+		return "No traffic found for " + describeScope(params.UserID, params.Host, params.PathPrefix) +
+			" in the specified date range.", nil
 	}
 
+	if groupBy == "host" {
+		return a.analyzeByHost(groups, params.Host, params.PathPrefix, offset, limit), nil
+	}
+	return a.analyzeByEndpoint(ctx, params.UserID, start, end, groups,
+		params.Host, params.PathPrefix, params.Summarize, offset, limit, state, notify), nil
+}
+
+// analyzeByHost rolls the path groups up to per-host counts and returns one
+// paginated page. No fast-model calls — this is the cheap "breadth of egress
+// destinations" view the agent uses to orient before drilling into endpoints.
+func (a *PolicyAgent) analyzeByHost(groups []PathGroup, hostFilter, pathPrefix string, offset, limit int) string {
+	type acc struct{ count, endpoints int }
+	byHost := map[string]*acc{}
+	order := make([]string, 0)
+	totalRequests := 0
+	for _, g := range groups {
+		h := hostFromPattern(g.PathPattern)
+		totalRequests += g.Count
+		cur, ok := byHost[h]
+		if !ok {
+			cur = &acc{}
+			byHost[h] = cur
+			order = append(order, h)
+		}
+		cur.count += g.Count
+		cur.endpoints++
+	}
+	hosts := make([]hostGroup, 0, len(order))
+	for _, h := range order {
+		hosts = append(hosts, hostGroup{host: h, count: byHost[h].count, endpointCount: byHost[h].endpoints})
+	}
+	sort.Slice(hosts, func(i, j int) bool { return hosts[i].count > hosts[j].count })
+
+	page := paginate(len(hosts), offset, limit)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d requests across %d distinct hosts%s.\n",
+		totalRequests, len(hosts), scopeSuffix(hostFilter, pathPrefix)))
+	writePageHeader(&sb, "hosts", offset, page, len(hosts),
+		"increase offset, or use group_by=\"endpoint\" with host=\"<host>\" to drill into one host's endpoints")
+	for _, hg := range hosts[page.start:page.end] {
+		sb.WriteString(fmt.Sprintf("- %s (%d requests, %d endpoints)\n", hg.host, hg.count, hg.endpointCount))
+	}
+	return sb.String()
+}
+
+// analyzeByEndpoint returns one paginated page of (method, path pattern) groups,
+// optionally with a fast-model description per endpoint. Summarization runs only
+// over the page (bounded by maxAnalyzeLimit), and summaries are persisted so the
+// draft's traffic context accumulates as the agent drills in.
+func (a *PolicyAgent) analyzeByEndpoint(
+	ctx context.Context, userID string, start, end time.Time, groups []PathGroup,
+	hostFilter, pathPrefix string, summarize bool, offset, limit int,
+	state *agentState, notify func(string, interface{}),
+) string {
+	totalRequests := 0
+	for _, g := range groups {
+		totalRequests += g.Count
+	}
+	page := paginate(len(groups), offset, limit)
+	pageGroups := groups[page.start:page.end]
+
+	var descriptions map[int]string
+	if summarize && len(pageGroups) > 0 {
+		descriptions = a.summarizePage(ctx, userID, start, end, pageGroups, notify)
+		for i, g := range pageGroups {
+			appendSummary(state, types.PolicyEndpointSummary{
+				Method: g.Method, PathPattern: g.PathPattern, Count: g.Count, Description: descriptions[i],
+			})
+		}
+		notify("summaries_updated", state.summaries)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d requests across %d distinct endpoints%s.\n",
+		totalRequests, len(groups), scopeSuffix(hostFilter, pathPrefix)))
+	hint := "increase offset, or narrow with host/path_prefix"
+	if !summarize {
+		hint = "set summarize=true for a description of each endpoint; " + hint
+	}
+	writePageHeader(&sb, "endpoints", offset, page, len(groups), hint)
+	for i, g := range pageGroups {
+		if summarize {
+			sb.WriteString(fmt.Sprintf("- %s %s (%d calls): %s\n", g.Method, g.PathPattern, g.Count, descriptions[i]))
+		} else {
+			sb.WriteString(fmt.Sprintf("- %s %s (%d calls)\n", g.Method, g.PathPattern, g.Count))
+		}
+	}
+	return sb.String()
+}
+
+// summarizePage runs the fast model over one page of endpoint groups concurrently
+// and returns descriptions keyed by their index within pageGroups.
+func (a *PolicyAgent) summarizePage(
+	ctx context.Context, userID string, start, end time.Time, pageGroups []PathGroup, notify func(string, interface{}),
+) map[int]string {
 	type indexed struct {
-		idx int
-		sum EndpointSummary
+		idx  int
+		desc string
 	}
-	results := make([]EndpointSummary, len(groups))
-	ch := make(chan indexed, len(groups))
+	ch := make(chan indexed, len(pageGroups))
 	sem := make(chan struct{}, agentConcurrency)
-
 	var wg sync.WaitGroup
-	for i, g := range groups {
+	for i, g := range pageGroups {
 		wg.Add(1)
 		go func(idx int, group PathGroup) {
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-
-			samples := a.reader.SampleRequestsForPath(params.UserID, group.Method, PathPrefixFromPattern(group.PathPattern), start, end, 200)
-			desc := summarizeEndpoint(ctx, a.fastAdapter, group.Method, group.PathPattern, group.Count, samples)
-			ch <- indexed{idx, EndpointSummary{Method: group.Method, PathPattern: group.PathPattern, Count: group.Count, Description: desc}}
+			samples := a.reader.SampleRequestsForPath(userID, group.Method, PathPrefixFromPattern(group.PathPattern), start, end, 200)
+			ch <- indexed{idx, summarizeEndpoint(ctx, a.fastAdapter, group.Method, group.PathPattern, group.Count, samples)}
 		}(i, g)
 	}
 	go func() { wg.Wait(); close(ch) }()
 
+	out := make(map[int]string, len(pageGroups))
 	completed := 0
 	for r := range ch {
-		results[r.idx] = r.sum
+		out[r.idx] = r.desc
 		completed++
 		notify("tool_progress", map[string]interface{}{
-			"message":   fmt.Sprintf("Summarized %s %s (%d/%d)", r.sum.Method, r.sum.PathPattern, completed, len(groups)),
+			"message":   fmt.Sprintf("Summarized %d/%d endpoints", completed, len(pageGroups)),
 			"completed": completed,
-			"total":     len(groups),
+			"total":     len(pageGroups),
 		})
 	}
+	return out
+}
 
-	for _, s := range results {
-		state.summaries = append(state.summaries, types.PolicyEndpointSummary{
-			Method:      s.Method,
-			PathPattern: s.PathPattern,
-			Count:       s.Count,
-			Description: s.Description,
-		})
+// pageRange is a half-open slice range [start, end).
+type pageRange struct{ start, end int }
+
+// paginate clamps offset/limit to a slice of length n. limit==0 yields an empty
+// page (counts-only); limit>0 yields up to limit rows starting at offset.
+func paginate(n, offset, limit int) pageRange {
+	if offset > n {
+		offset = n
 	}
-
-	notify("summaries_updated", state.summaries)
-
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("Found %d distinct endpoint patterns:\n", len(results)))
-	for _, s := range results {
-		sb.WriteString(fmt.Sprintf("- %s %s (%d calls): %s\n", s.Method, s.PathPattern, s.Count, s.Description))
+	if limit <= 0 {
+		return pageRange{offset, offset}
 	}
-	return sb.String(), nil
+	end := offset + limit
+	if end > n {
+		end = n
+	}
+	return pageRange{offset, end}
+}
+
+// writePageHeader emits the "Showing X–Y of N ..." line (and the more-available
+// hint) for a page, or a counts-only / past-the-end note when nothing is listed.
+func writePageHeader(sb *strings.Builder, unit string, offset int, page pageRange, total int, moreHint string) {
+	shown := page.end - page.start
+	if shown == 0 {
+		if offset >= total && total > 0 {
+			sb.WriteString(fmt.Sprintf("(offset %d is past the end; %d %s total.)\n", offset, total, unit))
+		} else {
+			sb.WriteString(fmt.Sprintf("(counts only — set limit>0 to list %s.)\n", unit))
+		}
+		return
+	}
+	sb.WriteString(fmt.Sprintf("Showing %s %d-%d of %d by request count.", unit, page.start+1, page.end, total))
+	if remaining := total - page.end; remaining > 0 {
+		sb.WriteString(fmt.Sprintf(" %d more — %s.", remaining, moreHint))
+	}
+	sb.WriteString("\n")
+}
+
+// scopeSuffix renders the active host/path_prefix filters for a header line.
+func scopeSuffix(host, pathPrefix string) string {
+	parts := make([]string, 0, 2)
+	if host != "" {
+		parts = append(parts, "host="+host)
+	}
+	if pathPrefix != "" {
+		parts = append(parts, "path_prefix="+pathPrefix)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " (filtered: " + strings.Join(parts, ", ") + ")"
+}
+
+// describeScope renders the user + active filters for the no-traffic message.
+func describeScope(userID, host, pathPrefix string) string {
+	return "user " + userID + scopeSuffix(host, pathPrefix)
+}
+
+// hostFromPattern extracts the host (with port) from a normalized URL pattern.
+// Hosts are not altered by NormalizeURL (its regexes exclude dotted/TLD segments),
+// so the host portion of the pattern is reliable.
+func hostFromPattern(pattern string) string {
+	rest := pattern
+	if i := strings.Index(pattern, "://"); i >= 0 {
+		rest = pattern[i+3:]
+	}
+	if j := strings.IndexByte(rest, '/'); j >= 0 {
+		return rest[:j]
+	}
+	return rest
+}
+
+// appendSummary upserts an endpoint summary into state by (method, path pattern),
+// so paging/re-running analyze_traffic does not duplicate the traffic context.
+func appendSummary(state *agentState, s types.PolicyEndpointSummary) {
+	for i := range state.summaries {
+		if state.summaries[i].Method == s.Method && state.summaries[i].PathPattern == s.PathPattern {
+			state.summaries[i] = s
+			return
+		}
+	}
+	state.summaries = append(state.summaries, s)
 }
 
 func (a *PolicyAgent) toolRemoveEndpoints(input json.RawMessage, state *agentState, notify func(string, interface{})) (string, error) {
@@ -400,7 +717,14 @@ Guidelines:
 - The policy_prompt is only evaluated for requests that do NOT match any static rule.
   Do not mention static-rule endpoints in the policy_prompt — they are already handled automatically.
   The policy_prompt should only describe what the LLM judge should allow or deny for everything else.
-- Call analyze_traffic at most once per user/date-range combination. Do not call it multiple times for the same user and period.
+- Use analyze_traffic to explore observed traffic before writing a policy. It is paginated and capped, so it
+  will never overwhelm your context; explore iteratively rather than trying to pull everything at once:
+  - Start broad: group_by="host" (the default) to see every destination domain with request and endpoint counts.
+  - Drill down: group_by="endpoint" with host="<domain>" (optionally path_prefix) to see a domain's specific
+    endpoints. Add summarize=true on a focused page when you need to know what each endpoint does.
+  - Page with limit/offset; each result tells you the totals and how many rows remain. Set limit=0 for counts only.
+  - Survey the hosts first, then drill into the ones that need their own rules. Do not assume the first page is
+    everything — check the reported totals and page further or filter when it matters for an accurate policy.
 - Never call remove_endpoints unless the user explicitly asks you to remove specific endpoints. Every endpoint in the traffic context — including health checks, auth callbacks, and anything that looks like noise — may need to be reflected in static rules or the policy prompt. Removing endpoints without being asked destroys context needed for an accurate policy.
 - Respond in plain text. Do not use markdown, headers, bullet points, tables, or code fences in your replies.
 
@@ -491,14 +815,25 @@ func PathPrefixFromPattern(pattern string) string {
 
 var agentTools = []llm.Tool{
 	{
-		Name:        "analyze_traffic",
-		Description: "Analyze observed HTTP traffic for a user over a date range to understand what API endpoints the agent accesses. Returns a list of endpoint patterns with call counts and descriptions. Call this before writing a policy.",
+		Name: "analyze_traffic",
+		Description: "Explore a user's observed HTTP traffic over a date range to understand what the agent accesses, before writing a policy. " +
+			"Results are always ordered by request count and PAGINATED (capped per call) so they never overflow your context. " +
+			"Start broad with group_by=\"host\" to see every destination domain with request and endpoint counts, then drill in " +
+			"with group_by=\"endpoint\" plus host/path_prefix filters. Use summarize=true only on a focused page to get a description " +
+			"of each endpoint. Page through results with limit/offset; each result reports the totals and how many rows remain. " +
+			"You may call this multiple times to page and drill down.",
 		InputSchema: json.RawMessage(`{
 			"type": "object",
 			"properties": {
 				"user_id":     {"type": "string", "description": "The user ID to analyze traffic for"},
 				"start_date":  {"type": "string", "description": "Start of date range in RFC3339 format (e.g. 2024-01-01T00:00:00Z)"},
-				"end_date":    {"type": "string", "description": "End of date range in RFC3339 format"}
+				"end_date":    {"type": "string", "description": "End of date range in RFC3339 format"},
+				"group_by":    {"type": "string", "enum": ["host", "endpoint"], "description": "Aggregation level. \"host\" (default) lists destination hosts with request and distinct-endpoint counts — use it for breadth. \"endpoint\" lists individual (method, path) patterns — use it for depth, usually with a host filter."},
+				"host":        {"type": "string", "description": "Optional. Restrict to a single host (e.g. \"api.example.com\"). Combine with group_by=\"endpoint\" to drill into one domain."},
+				"path_prefix": {"type": "string", "description": "Optional. Restrict to URLs whose path starts with this prefix (e.g. \"/v1/users\")."},
+				"summarize":   {"type": "boolean", "description": "Optional, group_by=\"endpoint\" only. When true, add a fast-model description of each returned endpoint (slower). Default false. Use on a focused page, not a broad scan."},
+				"limit":       {"type": "integer", "description": "Optional. Max rows to return this call. Default 50, hard-capped at 100. Set 0 to return only the totals (no list)."},
+				"offset":      {"type": "integer", "description": "Optional. Number of rows to skip, for paging through results. Default 0."}
 			},
 			"required": ["user_id", "start_date", "end_date"]
 		}`),

--- a/internal/builder/agent.go
+++ b/internal/builder/agent.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -271,31 +272,12 @@ func compactLargestToolResult(messages []llm.Message) bool {
 	return true
 }
 
-// isContextLengthError reports whether err looks like a provider rejecting the
-// request because it exceeded the model's context window. It matches on message
-// text to stay provider-agnostic (Bedrock, direct Anthropic, and OpenAI all
-// surface this differently), tolerating the surrounding wrapping each adds.
+// isContextLengthError reports whether err is a provider rejecting the request
+// because it exceeded the model's context window. The adapters classify this by
+// HTTP status / exception type (never a 429) and wrap llm.ErrContextLength, so a
+// rate-limit error is not misclassified as context overflow.
 func isContextLengthError(err error) bool {
-	if err == nil {
-		return false
-	}
-	s := strings.ToLower(err.Error())
-	switch {
-	case strings.Contains(s, "is too long"): // "input is too long", "prompt is too long"
-		return true
-	case strings.Contains(s, "context length") || strings.Contains(s, "context window"):
-		return true
-	case strings.Contains(s, "maximum context"):
-		return true
-	case strings.Contains(s, "context_length_exceeded"):
-		return true
-	case strings.Contains(s, "too many tokens") || strings.Contains(s, "too many input tokens"):
-		return true
-	case strings.Contains(s, "token") && strings.Contains(s, "exceed"):
-		return true
-	default:
-		return false
-	}
+	return errors.Is(err, llm.ErrContextLength)
 }
 
 type agentState struct {

--- a/internal/builder/agent.go
+++ b/internal/builder/agent.go
@@ -281,7 +281,7 @@ func isContextLengthError(err error) bool {
 	}
 	s := strings.ToLower(err.Error())
 	switch {
-	case strings.Contains(s, "too long"): // "input is too long", "prompt is too long"
+	case strings.Contains(s, "is too long"): // "input is too long", "prompt is too long"
 		return true
 	case strings.Contains(s, "context length") || strings.Contains(s, "context window"):
 		return true

--- a/internal/builder/agent_test.go
+++ b/internal/builder/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -18,8 +19,19 @@ type stubReader struct {
 	samples []RequestSample
 }
 
-func (r *stubReader) AggregatePathGroups(_ string, _, _ time.Time) []PathGroup {
-	return r.groups
+func (r *stubReader) AggregatePathGroups(_ string, _, _ time.Time, hostFilter, pathPrefix string) []PathGroup {
+	if hostFilter == "" && pathPrefix == "" {
+		return r.groups
+	}
+	// Honor the filters so pagination/drill-down tests are meaningful.
+	var out []PathGroup
+	for _, g := range r.groups {
+		if hostFilter != "" && hostFromPattern(g.PathPattern) != hostFilter {
+			continue
+		}
+		out = append(out, g)
+	}
+	return out
 }
 func (r *stubReader) SampleRequestsForPath(_, _, _ string, _, _ time.Time, _ int) []RequestSample {
 	return r.samples
@@ -93,10 +105,12 @@ func TestPolicyAgent_AnalyzeTraffic_Tool(t *testing.T) {
 	thinking := &llm.TestAdapter{Fn: func(req llm.Request) (llm.Response, error) {
 		callN++
 		if callN == 1 {
-			input, _ := json.Marshal(map[string]string{
+			input, _ := json.Marshal(map[string]interface{}{
 				"user_id":    "alice",
 				"start_date": "2024-01-01T00:00:00Z",
 				"end_date":   "2024-03-31T00:00:00Z",
+				"group_by":   "endpoint",
+				"summarize":  true,
 			})
 			return llm.Response{
 				StopReason: "tool_use",
@@ -128,6 +142,226 @@ func TestPolicyAgent_AnalyzeTraffic_Tool(t *testing.T) {
 	}
 }
 
+// analyzeViaThinking drives one analyze_traffic call through the agent and
+// returns the resulting tool-result content and the final agent result. It
+// keeps the cap/limit tests focused on behaviour rather than plumbing.
+func analyzeViaThinking(t *testing.T, reader *stubReader, input map[string]interface{}) (string, AgentResult) {
+	t.Helper()
+	fast := &llm.TestAdapter{Fn: func(_ llm.Request) (llm.Response, error) {
+		return llm.Response{Text: "desc"}, nil
+	}}
+	var toolResultContent string
+	callN := 0
+	thinking := &llm.TestAdapter{Fn: func(req llm.Request) (llm.Response, error) {
+		callN++
+		if callN == 1 {
+			raw, _ := json.Marshal(input)
+			return llm.Response{StopReason: "tool_use", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "analyze_traffic", Input: raw}}}, nil
+		}
+		for _, msg := range req.Messages {
+			if msg.ToolResult != nil {
+				toolResultContent = msg.ToolResult.Content
+			}
+		}
+		return llm.Response{Text: "done", StopReason: "end_turn"}, nil
+	}}
+	agent := NewPolicyAgent(reader, fast, thinking)
+	result, err := agent.Run(context.Background(), "", "", nil, nil, nil, "analyze", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return toolResultContent, result
+}
+
+// makeEndpointGroups builds n endpoint groups on a single host, counts descending.
+func makeEndpointGroups(host string, n int) []PathGroup {
+	groups := make([]PathGroup, n)
+	for i := range groups {
+		groups[i] = PathGroup{
+			Method:      "GET",
+			PathPattern: fmt.Sprintf("https://%s/v1/items/%d", host, i),
+			Count:       n - i,
+		}
+	}
+	return groups
+}
+
+// makeMultiHostGroups builds groups spread across numHosts hosts, perHost each.
+// Host h0 has the most traffic, h1 next, etc., so host ordering is deterministic.
+func makeMultiHostGroups(numHosts, perHost int) []PathGroup {
+	var groups []PathGroup
+	for h := 0; h < numHosts; h++ {
+		host := fmt.Sprintf("h%d.example.com", h)
+		base := (numHosts - h) * 1000 // h0 highest
+		for e := 0; e < perHost; e++ {
+			groups = append(groups, PathGroup{
+				Method:      "GET",
+				PathPattern: fmt.Sprintf("https://%s/p%d", host, e),
+				Count:       base - e,
+			})
+		}
+	}
+	return groups
+}
+
+func baseInput(extra map[string]interface{}) map[string]interface{} {
+	in := map[string]interface{}{
+		"user_id":    "alice",
+		"start_date": "2024-01-01T00:00:00Z",
+		"end_date":   "2024-03-31T00:00:00Z",
+	}
+	for k, v := range extra {
+		in[k] = v
+	}
+	return in
+}
+
+func TestAnalyzeTraffic_HostMode_DefaultIsBreadthNoSummaries(t *testing.T) {
+	// Default (no group_by) is host breadth: lists hosts with counts, runs no
+	// fast-model calls, and persists no endpoint summaries.
+	reader := &stubReader{groups: makeMultiHostGroups(5, 3)}
+	toolResult, result := analyzeViaThinking(t, reader, baseInput(nil))
+
+	if !strings.Contains(toolResult, "5 distinct hosts") {
+		t.Errorf("expected host count in result; got: %q", toolResult)
+	}
+	if !strings.Contains(toolResult, "h0.example.com (") {
+		t.Errorf("expected hosts listed with counts; got: %q", toolResult)
+	}
+	if strings.Contains(toolResult, "/p0") {
+		t.Errorf("host mode should not list endpoint paths; got: %q", toolResult)
+	}
+	if len(result.NewSummaries) != 0 {
+		t.Errorf("host mode should persist no summaries, got %d", len(result.NewSummaries))
+	}
+}
+
+func TestAnalyzeTraffic_EndpointPaginationReportsTotalAndRemaining(t *testing.T) {
+	reader := &stubReader{groups: makeEndpointGroups("api.example.com", 30)}
+	toolResult, result := analyzeViaThinking(t, reader, baseInput(map[string]interface{}{
+		"group_by": "endpoint", "limit": 10,
+	}))
+
+	if !strings.Contains(toolResult, "Showing endpoints 1-10 of 30") {
+		t.Errorf("expected pagination header; got: %q", toolResult)
+	}
+	if !strings.Contains(toolResult, "20 more") {
+		t.Errorf("expected remaining count; got: %q", toolResult)
+	}
+	// summarize defaults to false → no summaries, no descriptions.
+	if len(result.NewSummaries) != 0 {
+		t.Errorf("expected no summaries without summarize=true, got %d", len(result.NewSummaries))
+	}
+}
+
+func TestAnalyzeTraffic_LimitClampedToMax(t *testing.T) {
+	reader := &stubReader{groups: makeEndpointGroups("api.example.com", maxAnalyzeLimit+50)}
+	toolResult, _ := analyzeViaThinking(t, reader, baseInput(map[string]interface{}{
+		"group_by": "endpoint", "limit": 9999,
+	}))
+	if !strings.Contains(toolResult, fmt.Sprintf("Showing endpoints 1-%d of %d", maxAnalyzeLimit, maxAnalyzeLimit+50)) {
+		t.Errorf("expected limit clamped to %d; got: %q", maxAnalyzeLimit, toolResult)
+	}
+}
+
+func TestAnalyzeTraffic_CountsOnlyWhenLimitZero(t *testing.T) {
+	reader := &stubReader{groups: makeMultiHostGroups(4, 2)}
+	toolResult, _ := analyzeViaThinking(t, reader, baseInput(map[string]interface{}{
+		"limit": 0,
+	}))
+	if !strings.Contains(toolResult, "4 distinct hosts") {
+		t.Errorf("expected totals reported; got: %q", toolResult)
+	}
+	if !strings.Contains(toolResult, "counts only") {
+		t.Errorf("expected counts-only note; got: %q", toolResult)
+	}
+	if strings.Contains(toolResult, "- h") {
+		t.Errorf("limit=0 should list nothing; got: %q", toolResult)
+	}
+}
+
+func TestAnalyzeTraffic_HostFilterDrillDownSummarizesOnlyThatHost(t *testing.T) {
+	reader := &stubReader{
+		groups:  makeMultiHostGroups(3, 4), // 3 hosts × 4 endpoints
+		samples: []RequestSample{{URL: "https://h1.example.com/p0"}},
+	}
+	toolResult, result := analyzeViaThinking(t, reader, baseInput(map[string]interface{}{
+		"group_by": "endpoint", "host": "h1.example.com", "summarize": true,
+	}))
+
+	if !strings.Contains(toolResult, "4 distinct endpoints") {
+		t.Errorf("expected only the filtered host's endpoints; got: %q", toolResult)
+	}
+	if strings.Contains(toolResult, "h0.example.com") || strings.Contains(toolResult, "h2.example.com") {
+		t.Errorf("host filter leaked other hosts; got: %q", toolResult)
+	}
+	if len(result.NewSummaries) != 4 {
+		t.Errorf("expected 4 summaries for the filtered host, got %d", len(result.NewSummaries))
+	}
+}
+
+func TestAnalyzeTraffic_SummarizationBoundedToPage(t *testing.T) {
+	// Even with 60 endpoints, summarize must only run over the requested page.
+	reader := &stubReader{
+		groups:  makeEndpointGroups("api.example.com", 60),
+		samples: []RequestSample{{URL: "https://api.example.com/v1/items/0"}},
+	}
+	_, result := analyzeViaThinking(t, reader, baseInput(map[string]interface{}{
+		"group_by": "endpoint", "summarize": true, "limit": 5,
+	}))
+	if len(result.NewSummaries) != 5 {
+		t.Errorf("expected summarization bounded to the 5-row page, got %d", len(result.NewSummaries))
+	}
+}
+
+func TestAnalyzeTraffic_RecoversFromContextError(t *testing.T) {
+	// First thinking call after the tool returns fails with a context-length error;
+	// the loop must shrink the oversized tool result and succeed on retry.
+	reader := &stubReader{groups: makeEndpointGroups("api.example.com", 30)}
+	fast := &llm.TestAdapter{Fn: func(_ llm.Request) (llm.Response, error) { return llm.Response{Text: "d"}, nil }}
+	call := 0
+	thinking := &llm.TestAdapter{Fn: func(req llm.Request) (llm.Response, error) {
+		call++
+		switch call {
+		case 1:
+			in, _ := json.Marshal(baseInput(map[string]interface{}{"group_by": "endpoint", "limit": 30}))
+			return llm.Response{StopReason: "tool_use", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "analyze_traffic", Input: in}}}, nil
+		case 2:
+			return llm.Response{}, errors.New("ValidationException: input is too long for requested model")
+		default:
+			return llm.Response{Text: "recovered", StopReason: "end_turn"}, nil
+		}
+	}}
+	agent := NewPolicyAgent(reader, fast, thinking)
+	result, err := agent.Run(context.Background(), "", "", nil, nil, nil, "analyze", nil)
+	if err != nil {
+		t.Fatalf("expected graceful recovery, got error: %v", err)
+	}
+	if result.Message != "recovered" {
+		t.Errorf("expected loop to retry and succeed, got message: %q", result.Message)
+	}
+}
+
+func TestIsContextLengthError(t *testing.T) {
+	hits := []string{
+		"ValidationException: input is too long for requested model",
+		"prompt is too long: 250000 tokens > 200000",
+		"This model's maximum context length is 200000 tokens",
+		"context_length_exceeded",
+		"too many input tokens",
+	}
+	for _, m := range hits {
+		if !isContextLengthError(errors.New(m)) {
+			t.Errorf("expected context-length error for %q", m)
+		}
+	}
+	for _, m := range []string{"model unavailable", "throttled", "connection reset"} {
+		if isContextLengthError(errors.New(m)) {
+			t.Errorf("did not expect context-length error for %q", m)
+		}
+	}
+}
+
 func TestPolicyAgent_MultiTool_AccumulatesSummaries(t *testing.T) {
 	reader := &stubReader{
 		groups:  []PathGroup{{Method: "POST", PathPattern: "/v1/jobs", Count: 10}},
@@ -146,7 +380,7 @@ func TestPolicyAgent_MultiTool_AccumulatesSummaries(t *testing.T) {
 		callN++
 		switch callN {
 		case 1:
-			input, _ := json.Marshal(map[string]string{"user_id": "bob", "start_date": "2024-01-01T00:00:00Z", "end_date": "2024-02-01T00:00:00Z"})
+			input, _ := json.Marshal(map[string]interface{}{"user_id": "bob", "start_date": "2024-01-01T00:00:00Z", "end_date": "2024-02-01T00:00:00Z", "group_by": "endpoint", "summarize": true})
 			return llm.Response{StopReason: "tool_use", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "analyze_traffic", Input: input}}}, nil
 		case 2:
 			return llm.Response{Text: "Done.", StopReason: "end_turn"}, nil

--- a/internal/builder/agent_test.go
+++ b/internal/builder/agent_test.go
@@ -23,15 +23,32 @@ func (r *stubReader) AggregatePathGroups(_ string, _, _ time.Time, hostFilter, p
 	if hostFilter == "" && pathPrefix == "" {
 		return r.groups
 	}
-	// Honor the filters so pagination/drill-down tests are meaningful.
+	// Honor the filters so pagination/drill-down tests are meaningful. pathPrefix
+	// is a literal prefix match, mirroring the reader's starts_with() in SQL.
 	var out []PathGroup
 	for _, g := range r.groups {
 		if hostFilter != "" && hostFromPattern(g.PathPattern) != hostFilter {
 			continue
 		}
+		if pathPrefix != "" && !strings.HasPrefix(pathFromPattern(g.PathPattern), pathPrefix) {
+			continue
+		}
 		out = append(out, g)
 	}
 	return out
+}
+
+// pathFromPattern returns the URL path (with leading slash) from a normalized
+// pattern, mirroring how the reader strips scheme+host before the prefix match.
+func pathFromPattern(pattern string) string {
+	rest := pattern
+	if i := strings.Index(pattern, "://"); i >= 0 {
+		rest = pattern[i+3:]
+	}
+	if j := strings.IndexByte(rest, '/'); j >= 0 {
+		return rest[j:]
+	}
+	return "/"
 }
 func (r *stubReader) SampleRequestsForPath(_, _, _ string, _, _ time.Time, _ int) []RequestSample {
 	return r.samples
@@ -297,6 +314,27 @@ func TestAnalyzeTraffic_HostFilterDrillDownSummarizesOnlyThatHost(t *testing.T) 
 	}
 	if len(result.NewSummaries) != 4 {
 		t.Errorf("expected 4 summaries for the filtered host, got %d", len(result.NewSummaries))
+	}
+}
+
+func TestAnalyzeTraffic_PathPrefixFilterIsLiteral(t *testing.T) {
+	host := "api.example.com"
+	reader := &stubReader{groups: []PathGroup{
+		{Method: "GET", PathPattern: "https://" + host + "/v1/users/{id}", Count: 12},
+		{Method: "GET", PathPattern: "https://" + host + "/v1/users/{id}/roles", Count: 8},
+		{Method: "GET", PathPattern: "https://" + host + "/v1/orders/{id}", Count: 5},
+		{Method: "GET", PathPattern: "https://" + host + "/v1/user_settings", Count: 3}, // underscore sibling
+	}}
+	toolResult, _ := analyzeViaThinking(t, reader, baseInput(map[string]interface{}{
+		"group_by": "endpoint", "host": host, "path_prefix": "/v1/users/",
+	}))
+	if !strings.Contains(toolResult, "2 distinct endpoints") {
+		t.Errorf("expected only the 2 /v1/users/ endpoints; got: %q", toolResult)
+	}
+	// Literal prefix (starts_with, not LIKE): the underscore sibling and the
+	// orders family must be excluded rather than wildcard-matched.
+	if strings.Contains(toolResult, "user_settings") || strings.Contains(toolResult, "/v1/orders/") {
+		t.Errorf("path_prefix should match literally; got: %q", toolResult)
 	}
 }
 

--- a/internal/builder/agent_test.go
+++ b/internal/builder/agent_test.go
@@ -365,7 +365,9 @@ func TestAnalyzeTraffic_RecoversFromContextError(t *testing.T) {
 			in, _ := json.Marshal(baseInput(map[string]interface{}{"group_by": "endpoint", "limit": 30}))
 			return llm.Response{StopReason: "tool_use", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "analyze_traffic", Input: in}}}, nil
 		case 2:
-			return llm.Response{}, errors.New("ValidationException: input is too long for requested model")
+			// Mirror how an adapter surfaces a context overflow: the provider error
+			// wrapping llm.ErrContextLength.
+			return llm.Response{}, fmt.Errorf("bedrock invoke failed: %s: %w", "ValidationException: input is too long for requested model", llm.ErrContextLength)
 		default:
 			return llm.Response{Text: "recovered", StopReason: "end_turn"}, nil
 		}
@@ -381,21 +383,26 @@ func TestAnalyzeTraffic_RecoversFromContextError(t *testing.T) {
 }
 
 func TestIsContextLengthError(t *testing.T) {
-	hits := []string{
-		"ValidationException: input is too long for requested model",
-		"prompt is too long: 250000 tokens > 200000",
-		"This model's maximum context length is 200000 tokens",
-		"context_length_exceeded",
-		"too many input tokens",
+	// Only errors wrapping llm.ErrContextLength (set by the adapters after a
+	// status-code/exception-type gate) count — regardless of message text.
+	wrapped := fmt.Errorf("anthropic API error (status 400): prompt is too long: %w", llm.ErrContextLength)
+	if !isContextLengthError(wrapped) {
+		t.Error("expected wrapped llm.ErrContextLength to be detected")
 	}
-	for _, m := range hits {
-		if !isContextLengthError(errors.New(m)) {
-			t.Errorf("expected context-length error for %q", m)
-		}
+	if !isContextLengthError(fmt.Errorf("agent call failed: %w", wrapped)) {
+		t.Error("expected detection through an extra wrap layer")
 	}
-	for _, m := range []string{"model unavailable", "throttled", "connection reset"} {
+	// Crucially, a message that merely *looks* like a context error but does NOT
+	// wrap the sentinel must not match — this is what prevents 429 rate-limit
+	// errors ("rate_limit_exceeded ... tokens per minute") from being swallowed.
+	for _, m := range []string{
+		"rate_limit_exceeded: 30000 tokens per minute exceeded",
+		"ValidationException: input is too long for requested model", // no sentinel -> not ours
+		"model unavailable",
+		"connection reset",
+	} {
 		if isContextLengthError(errors.New(m)) {
-			t.Errorf("did not expect context-length error for %q", m)
+			t.Errorf("did not expect context-length error for unwrapped %q", m)
 		}
 	}
 }

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -123,6 +123,11 @@ func (a *AnthropicAdapter) Complete(ctx context.Context, req Request) (Response,
 	if httpResp.StatusCode != http.StatusOK {
 		a.RecordFailure()
 		errBody, _ := io.ReadAll(httpResp.Body)
+		// A context-overflow is a 400 invalid_request_error ("prompt is too long");
+		// gate on the status so 429 rate-limit errors are never misclassified.
+		if httpResp.StatusCode == http.StatusBadRequest && bodyIndicatesContextLength(string(errBody)) {
+			return Response{DurationMs: durationMs}, fmt.Errorf("anthropic API error (status %d): %s: %w", httpResp.StatusCode, string(errBody), ErrContextLength)
+		}
 		return Response{DurationMs: durationMs}, fmt.Errorf("anthropic API error (status %d): %s", httpResp.StatusCode, string(errBody))
 	}
 

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -238,6 +239,25 @@ func TestAnthropicAPIError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for 429 response")
+	}
+	// A 429 rate-limit must not be classified as a context overflow.
+	if errors.Is(err, ErrContextLength) {
+		t.Errorf("429 rate-limit must not match ErrContextLength: %v", err)
+	}
+}
+
+func TestAnthropicContextLengthClassification(t *testing.T) {
+	// 400 invalid_request_error "prompt is too long" -> ErrContextLength.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 250000 tokens > 200000 maximum"}}`))
+	}))
+	defer srv.Close()
+
+	adapter := newTestAnthropicAdapter(t, "claude-sonnet-4-20250514", "test-key", srv.URL)
+	_, err := adapter.Complete(context.Background(), Request{Messages: []Message{{Role: "user", Content: "hi"}}})
+	if !errors.Is(err, ErrContextLength) {
+		t.Errorf("expected ErrContextLength for 400 prompt-too-long, got %v", err)
 	}
 }
 

--- a/internal/llm/bedrock.go
+++ b/internal/llm/bedrock.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -10,7 +11,20 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 )
+
+// isBedrockContextLengthError reports whether err is a Bedrock ValidationException
+// caused by the input exceeding the model's context window. It matches only the
+// ValidationException type (not ThrottlingException), so 429 throttling is never
+// treated as a context overflow.
+func isBedrockContextLengthError(err error) bool {
+	var ve *bedrocktypes.ValidationException
+	if errors.As(err, &ve) {
+		return bodyIndicatesContextLength(ve.ErrorMessage())
+	}
+	return false
+}
 
 // BedrockAdapter calls Anthropic models via AWS Bedrock.
 type BedrockAdapter struct {
@@ -140,6 +154,12 @@ func (a *BedrockAdapter) Complete(ctx context.Context, req Request) (Response, e
 	a.RecordJudgeLatency(a.model, elapsed)
 	if err != nil {
 		a.RecordFailure()
+		// A context-overflow surfaces as a ValidationException with a too-long
+		// message; gate on that type so a ThrottlingException (429) is never
+		// misclassified as context overflow.
+		if isBedrockContextLengthError(err) {
+			return Response{DurationMs: durationMs}, fmt.Errorf("bedrock invoke failed: %w: %w", err, ErrContextLength)
+		}
 		return Response{DurationMs: durationMs}, fmt.Errorf("bedrock invoke failed: %w", err)
 	}
 

--- a/internal/llm/bedrock_test.go
+++ b/internal/llm/bedrock_test.go
@@ -3,11 +3,36 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 )
+
+func TestBedrockContextLengthClassification(t *testing.T) {
+	// ValidationException with a too-long message -> ErrContextLength.
+	ve := newTestAdapter(func(ctx context.Context, in *bedrockruntime.InvokeModelInput) (*bedrockruntime.InvokeModelOutput, error) {
+		return nil, &bedrocktypes.ValidationException{Message: aws.String("input is too long for requested model")}
+	})
+	if _, err := ve.Complete(context.Background(), Request{Messages: []Message{{Role: "user", Content: "hi"}}}); !errors.Is(err, ErrContextLength) {
+		t.Errorf("expected ErrContextLength for ValidationException too-long, got %v", err)
+	}
+
+	// ThrottlingException (429) mentioning tokens -> NOT ErrContextLength.
+	thr := newTestAdapter(func(ctx context.Context, in *bedrockruntime.InvokeModelInput) (*bedrockruntime.InvokeModelOutput, error) {
+		return nil, &bedrocktypes.ThrottlingException{Message: aws.String("Too many tokens, please retry")}
+	})
+	_, err := thr.Complete(context.Background(), Request{Messages: []Message{{Role: "user", Content: "hi"}}})
+	if err == nil {
+		t.Fatal("expected error for throttling")
+	}
+	if errors.Is(err, ErrContextLength) {
+		t.Errorf("ThrottlingException must not match ErrContextLength: %v", err)
+	}
+}
 
 // newTestAdapter creates a BedrockAdapter wired to a stub invoker for unit tests.
 // It bypasses NewBedrockAdapter (which needs real AWS creds) and builds the struct

--- a/internal/llm/errors.go
+++ b/internal/llm/errors.go
@@ -1,0 +1,28 @@
+package llm
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrContextLength is wrapped by an adapter when a request was rejected because
+// it exceeded the model's context window. Callers detect it with errors.Is.
+//
+// Adapters set it ONLY for genuine context-overflow signals — an HTTP 400
+// (Anthropic/OpenAI) or a Bedrock ValidationException whose message indicates
+// the input is too long. It is never set for 429 throttling / rate-limit
+// errors, so those are not misclassified as context overflow.
+var ErrContextLength = errors.New("model context length exceeded")
+
+// bodyIndicatesContextLength reports whether a provider error message describes a
+// context-window overflow. It is the discriminator applied AFTER the status code
+// (or exception type) has already confirmed a client-request error rather than a
+// 429: only OpenAI emits a distinct machine code (context_length_exceeded), so
+// for Anthropic and Bedrock the message text is the only available signal.
+func bodyIndicatesContextLength(s string) bool {
+	s = strings.ToLower(s)
+	return strings.Contains(s, "context_length_exceeded") || // OpenAI code
+		strings.Contains(s, "is too long") || // Anthropic "prompt is too long", Bedrock "input is too long"
+		strings.Contains(s, "maximum context length") || // OpenAI message
+		strings.Contains(s, "context window")
+}

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -99,6 +99,11 @@ func (a *OpenAIAdapter) Complete(ctx context.Context, req Request) (Response, er
 	if httpResp.StatusCode != http.StatusOK {
 		a.RecordFailure()
 		errBody, _ := io.ReadAll(httpResp.Body)
+		// context_length_exceeded is a 400; insufficient_quota / rate limits are 429,
+		// so gating on the status keeps throttling out of the context-overflow path.
+		if httpResp.StatusCode == http.StatusBadRequest && bodyIndicatesContextLength(string(errBody)) {
+			return Response{DurationMs: durationMs}, fmt.Errorf("openai API error (status %d): %s: %w", httpResp.StatusCode, string(errBody), ErrContextLength)
+		}
 		return Response{DurationMs: durationMs}, fmt.Errorf("openai API error (status %d): %s", httpResp.StatusCode, string(errBody))
 	}
 

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -3,12 +3,41 @@ package llm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 )
+
+func TestOpenAIContextLengthClassification(t *testing.T) {
+	// 400 context_length_exceeded -> ErrContextLength.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":{"message":"This model's maximum context length is 128000 tokens, however you requested 200000.","type":"invalid_request_error","code":"context_length_exceeded"}}`))
+	}))
+	defer srv.Close()
+	a := newTestOpenAIAdapter(t, "gpt-4o", "test-key", srv.URL)
+	if _, err := a.Complete(context.Background(), Request{Messages: []Message{{Role: "user", Content: "hi"}}}); !errors.Is(err, ErrContextLength) {
+		t.Errorf("expected ErrContextLength for context_length_exceeded, got %v", err)
+	}
+
+	// 429 rate-limit mentioning tokens -> NOT ErrContextLength.
+	srv429 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"error":{"message":"Rate limit reached: 30000 tokens per min.","type":"tokens","code":"rate_limit_exceeded"}}`))
+	}))
+	defer srv429.Close()
+	a2 := newTestOpenAIAdapter(t, "gpt-4o", "test-key", srv429.URL)
+	_, err := a2.Complete(context.Background(), Request{Messages: []Message{{Role: "user", Content: "hi"}}})
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+	if errors.Is(err, ErrContextLength) {
+		t.Errorf("429 rate-limit must not match ErrContextLength: %v", err)
+	}
+}
 
 func openAISuccessResponse() []byte {
 	resp := map[string]interface{}{

--- a/web/src/components/PolicyDetail.tsx
+++ b/web/src/components/PolicyDetail.tsx
@@ -136,6 +136,7 @@ type AgentEvent =
   | { kind: 'user'; content: string }
   | { kind: 'assistant'; content: string }
   | { kind: 'tool'; tool: string; done: boolean; input?: unknown; result?: string; progressMessage?: string; completed?: number; total?: number }
+  | { kind: 'notice'; message: string }
   | { kind: 'error'; message: string }
 
 function DraftEditor({ policy, metadata, onSaved, onPublished, onDeleted, initialMessage }: {
@@ -307,6 +308,9 @@ function DraftEditor({ policy, metadata, onSaved, onPublished, onDeleted, initia
       case 'summaries_updated':
         setSummaries(data as import('../types').PolicyEndpointSummary[])
         break
+      case 'context_recovery':
+        setStreamingEvents((prev) => [...prev, { kind: 'notice', message: d.message as string }])
+        break
       case 'error':
         setStreamingEvents((prev) => [...prev, { kind: 'error', message: d.message as string }])
         break
@@ -416,7 +420,22 @@ function DraftEditor({ policy, metadata, onSaved, onPublished, onDeleted, initia
               )
               if (ev.kind === 'tool') {
                 const isAnalyze = ev.tool === 'analyze_traffic'
-                const inp = ev.input as Record<string, string> | undefined
+                const inp = (ev.input ?? {}) as Record<string, unknown>
+                const str = (v: unknown) => (typeof v === 'string' ? v : '')
+                // Compact list of the analyze_traffic scope/paging params (user_id and
+                // dates are rendered on their own line above this).
+                const analyzeParams: string[] = []
+                if (isAnalyze) {
+                  analyzeParams.push(`group_by=${str(inp.group_by) || 'host'}`)
+                  if (inp.host) analyzeParams.push(`host=${str(inp.host)}`)
+                  if (inp.path_prefix) analyzeParams.push(`path_prefix=${str(inp.path_prefix)}`)
+                  if (inp.summarize === true) analyzeParams.push('summarize')
+                  if (inp.limit != null) analyzeParams.push(`limit=${inp.limit as number}`)
+                  if (inp.offset != null && inp.offset !== 0) analyzeParams.push(`offset=${inp.offset as number}`)
+                }
+                // The first line of the tool result carries the totals, e.g.
+                // "306177 requests across 193 distinct hosts." — surface it as the result count.
+                const resultSummary = ev.done && typeof ev.result === 'string' ? ev.result.split('\n')[0].trim() : ''
                 return (
                   <div key={i} className="text-xs px-2 space-y-1">
                     {/* Tool name + status */}
@@ -428,11 +447,16 @@ function DraftEditor({ policy, metadata, onSaved, onPublished, onDeleted, initia
                       <span className={`font-mono ${ev.done ? 'text-gray-400' : 'text-blue-600'}`}>{ev.tool}</span>
                     </div>
 
-                    {/* Input params (analyze_traffic only) */}
-                    {isAnalyze && inp && (
+                    {/* Input: user + date range (analyze_traffic only) */}
+                    {isAnalyze && !!inp.user_id && (
                       <div className="pl-4 text-gray-400 font-mono">
-                        {inp.user_id} · {inp.start_date?.slice(0, 16).replace('T', ' ')} → {inp.end_date?.slice(0, 16).replace('T', ' ')}
+                        {str(inp.user_id)} · {str(inp.start_date).slice(0, 16).replace('T', ' ')} → {str(inp.end_date).slice(0, 16).replace('T', ' ')}
                       </div>
+                    )}
+
+                    {/* Input: scope / paging params (analyze_traffic only) */}
+                    {isAnalyze && analyzeParams.length > 0 && (
+                      <div className="pl-4 text-gray-400 font-mono">{analyzeParams.join(' · ')}</div>
                     )}
 
                     {/* Progress while running */}
@@ -447,9 +471,17 @@ function DraftEditor({ policy, metadata, onSaved, onPublished, onDeleted, initia
                       </div>
                     )}
 
+                    {/* Result count after completion (analyze_traffic only) */}
+                    {isAnalyze && resultSummary && (
+                      <div className="pl-4 text-gray-500">{resultSummary}</div>
+                    )}
+
                   </div>
                 )
               }
+              if (ev.kind === 'notice') return (
+                <div key={i} className="text-xs text-amber-700 bg-amber-50 rounded px-2 py-1">{ev.message}</div>
+              )
               if (ev.kind === 'error') return (
                 <div key={i} className="text-xs text-red-600 bg-red-50 rounded px-2 py-1">{ev.message}</div>
               )


### PR DESCRIPTION
The policy-builder agent's analyze_traffic tool summarised and returned every distinct endpoint pattern in a single tool result. For a high-volume user that could be many thousands of patterns, producing a tool result large enough to overflow the agent model's context window on the next turn — surfacing to the user as a generic "network error" after the tool appeared to run.

Redesign the tool to give the agent bounded, explorable views instead of one unbounded dump:

- group_by="host" (default): per-host request and distinct-endpoint counts — cheap breadth of egress destinations, no fast-model calls.
- group_by="endpoint": individual (method, path) patterns, optionally with host/path_prefix filters and opt-in per-endpoint summaries.
- limit (default 50, hard-capped 100) + offset pagination; limit=0 returns counts only. Every result reports totals and how many rows remain.

Summarisation now runs only over the returned page, so the fast-model fan-out is bounded too. The existing URL normalizer is unchanged; granularity is the agent's choice via parameters.

As a backstop, the agent loop detects context-length errors from the provider (Bedrock / Anthropic / OpenAI), shrinks the largest tool result in the conversation and retries, and degrades to an actionable message instead of a fatal error if it still cannot fit.

The admin UI surfaces each analyze_traffic call's parameters and result count so repeated drill-down calls are legible rather than looking redundant.