### PR TITLE
docs: add Ecosystem section with community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ This builds cross-platform binaries (linux/darwin, amd64/arm64), creates a GitHu
 
 See [CONTRIBUTING.md](CONTRIBUTING.md#releasing-with-goreleaser) for release notes and commit message conventions.
 
+## Ecosystem
+
+Community integrations that build on CrabTrap's decisions:
+
+- **[Fidacy](https://github.com/fidacy/fidacy-open/tree/main/packages/fidacy-crabtrap)** (`@fidacy/crabtrap`) — turns each CrabTrap allow/deny into an independently verifiable, Ed25519-signed trust verdict. CrabTrap stays the local judge; Fidacy adds a signed record any counterparty, auditor, or insurer can verify against public keys — no changes to your CrabTrap setup (consumes the SSE event feed).
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
Adds a small **Ecosystem** section to the README listing community integrations that build on CrabTrap's decisions — starting with [`@fidacy/crabtrap`](https://www.npmjs.com/package/@fidacy/crabtrap) (Apache-2.0, ~165 weekly npm downloads), which consumes CrabTrap's SSE event feed and turns each allow/deny into an independently verifiable, Ed25519-signed verdict that any counterparty can check against public keys.

No changes to CrabTrap itself — the adapter is read-only over the event feed, and this PR only adds documentation. Happy to adjust placement/wording to whatever fits your docs conventions, or to move it to a different file if you prefer.
