### PR TITLE
fix(approval): match static-rule hosts case-insensitively

### DIFF
--- a/internal/approval/hostcase_test.go
+++ b/internal/approval/hostcase_test.go
@@ -1,0 +1,56 @@
+package approval
+
+import (
+	"testing"
+
+	"github.com/brexhq/CrabTrap/pkg/types"
+)
+
+// TestStaticRuleHostCaseInsensitive checks that static rules match hosts
+// without regard to case. Host names are case-insensitive (RFC 4343), so a
+// rule written in lower case has to match a request that varies the case of
+// the host; both reach the same server. Paths stay case-sensitive.
+func TestStaticRuleHostCaseInsensitive(t *testing.T) {
+	rule := func(pattern, matchType, action string) []types.StaticRule {
+		return []types.StaticRule{{URLPattern: pattern, MatchType: matchType, Action: action}}
+	}
+
+	cases := []struct {
+		name       string
+		rules      []types.StaticRule
+		url        string
+		wantAction string // "" means no rule should match
+	}{
+		// allow rules must still match when the request varies host case
+		{"prefix allow, upper host", rule("https://api.example.com/", "prefix", "allow"), "https://API.EXAMPLE.COM/v1", "allow"},
+		{"glob allow, mixed subdomain", rule("*.example.com/*", "glob", "allow"), "https://API.Example.com/v1/users", "allow"},
+
+		// deny rules likewise
+		{"prefix deny, upper host", rule("https://internal.example.com/", "prefix", "deny"), "https://INTERNAL.EXAMPLE.COM/secrets", "deny"},
+		{"prefix deny, mixed host", rule("https://internal.example.com/", "prefix", "deny"), "https://Internal.Example.com/secrets", "deny"},
+		{"exact deny, mixed host", rule("https://internal.example.com/x", "exact", "deny"), "https://Internal.Example.com/x", "deny"},
+		{"glob deny, upper host", rule("internal.example.com/*", "glob", "deny"), "https://INTERNAL.EXAMPLE.COM/secrets", "deny"},
+
+		// a pattern authored in upper case must match a lower-case request too
+		{"upper-case rule, lower-case url", rule("https://API.EXAMPLE.COM/", "prefix", "allow"), "https://api.example.com/v1", "allow"},
+
+		// only the authority is folded, so path case still matters
+		{"path case differs", rule("https://api.example.com/Users", "exact", "allow"), "https://api.example.com/users", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, action := MatchesStaticRules("POST", tc.url, tc.rules)
+			if tc.wantAction == "" {
+				if matched {
+					t.Errorf("MatchesStaticRules(%q) matched with action %q, want no match", tc.url, action)
+				}
+				return
+			}
+			if !matched || action != tc.wantAction {
+				t.Errorf("MatchesStaticRules(%q) = (matched=%v, action=%q), want (true, %q)",
+					tc.url, matched, action, tc.wantAction)
+			}
+		})
+	}
+}

--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -401,6 +401,32 @@ func stripDefaultPort(rawURL string) string {
 	return rawURL
 }
 
+// lowerAuthority lowercases the scheme and host of a URL or URL-like pattern
+// while leaving the path, query, and fragment untouched. Host names and
+// schemes are case-insensitive, but paths and query strings are not, so only
+// the authority may be folded. Any userinfo before "@" is preserved as-is.
+// A bare pattern with no scheme (e.g. "example.com/*") is treated as
+// starting with its authority.
+func lowerAuthority(s string) string {
+	schemeEnd := 0
+	if i := strings.Index(s, "://"); i >= 0 {
+		schemeEnd = i + len("://")
+	}
+	rest := s[schemeEnd:]
+	end := strings.IndexAny(rest, "/?#")
+	if end < 0 {
+		end = len(rest)
+	}
+	authority := rest[:end]
+	host := authority
+	userinfo := ""
+	if at := strings.LastIndex(authority, "@"); at >= 0 {
+		userinfo = authority[:at+1]
+		host = authority[at+1:]
+	}
+	return strings.ToLower(s[:schemeEnd]) + userinfo + strings.ToLower(host) + rest[end:]
+}
+
 func staticURLMatches(urlStr, pattern, matchType string) bool {
 	// Decode percent-encoding so that e.g. "/%61dmin" matches a rule for "/admin".
 	// Use a single-pass decode only — do NOT decode recursively to prevent
@@ -414,6 +440,15 @@ func staticURLMatches(urlStr, pattern, matchType string) bool {
 	// matches a rule written as "https://host/path" and vice-versa.
 	decoded = stripDefaultPort(decoded)
 	normalizedPattern := stripDefaultPort(pattern)
+
+	// Host names are case-insensitive (RFC 4343), so fold the scheme and host
+	// of both the URL and the pattern to lower case before comparing. Without
+	// this a rule for "api.example.com" does not match a request to
+	// "API.Example.com" even though both reach the same server. Only the
+	// authority is folded; the path and query are left as-is because those
+	// are case-sensitive.
+	decoded = lowerAuthority(decoded)
+	normalizedPattern = lowerAuthority(normalizedPattern)
 
 	switch matchType {
 	case "exact":

--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -436,19 +436,23 @@ func staticURLMatches(urlStr, pattern, matchType string) bool {
 		decoded = urlStr // fall back to raw string on decode error
 	}
 
-	// Normalize away default ports so that e.g. "https://host:443/path"
-	// matches a rule written as "https://host/path" and vice-versa.
-	decoded = stripDefaultPort(decoded)
-	normalizedPattern := stripDefaultPort(pattern)
-
 	// Host names are case-insensitive (RFC 4343), so fold the scheme and host
 	// of both the URL and the pattern to lower case before comparing. Without
 	// this a rule for "api.example.com" does not match a request to
 	// "API.Example.com" even though both reach the same server. Only the
 	// authority is folded; the path and query are left as-is because those
 	// are case-sensitive.
+	//
+	// This runs before stripDefaultPort because that function matches the
+	// scheme case-sensitively, so an uppercase scheme would otherwise keep
+	// its redundant default port.
 	decoded = lowerAuthority(decoded)
-	normalizedPattern = lowerAuthority(normalizedPattern)
+	normalizedPattern := lowerAuthority(pattern)
+
+	// Normalize away default ports so that e.g. "https://host:443/path"
+	// matches a rule written as "https://host/path" and vice-versa.
+	decoded = stripDefaultPort(decoded)
+	normalizedPattern = stripDefaultPort(normalizedPattern)
 
 	switch matchType {
 	case "exact":

--- a/internal/approval/manager_llm_test.go
+++ b/internal/approval/manager_llm_test.go
@@ -497,6 +497,10 @@ func TestStaticURLMatches(t *testing.T) {
 		{"HTTPS://Example.Com/repos", "https://example.com/repos", "exact", true},
 		{"https://API.Example.com/x", "*.example.com/*", "glob", true},
 		{"https://example.com/Repos", "https://example.com/repos", "exact", false}, // path case is preserved
+		// an uppercase scheme must still have its default port stripped, so the
+		// case fold has to happen before stripDefaultPort inspects the scheme
+		{"https://api.example.com/v1", "HTTPS://api.example.com:443/v1", "exact", true},
+		{"http://api.example.com/v1", "HTTP://api.example.com:80/v1", "exact", true},
 	}
 
 	for _, tc := range cases {

--- a/internal/approval/manager_llm_test.go
+++ b/internal/approval/manager_llm_test.go
@@ -492,6 +492,11 @@ func TestStaticURLMatches(t *testing.T) {
 		{"http://example.com:8080/foo", "http://example.com/", "prefix", false},
 		{"https://example.com:443/foo", "*.example.com/*", "glob", true},
 		{"http://example.com:80/foo", "example.com/*", "glob", true},
+		// host matching is case-insensitive; scheme and host fold, path does not
+		{"https://EXAMPLE.COM/repos", "https://example.com/", "prefix", true},
+		{"HTTPS://Example.Com/repos", "https://example.com/repos", "exact", true},
+		{"https://API.Example.com/x", "*.example.com/*", "glob", true},
+		{"https://example.com/Repos", "https://example.com/repos", "exact", false}, // path case is preserved
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Problem

Host names are case-insensitive (RFC 4343), but `staticURLMatches` compares the URL and the rule pattern byte for byte. A rule written in lower case does not match a request that varies the case of the host, even though both reach the same server.

The effect shows up most often on allow rules. A rule for `*.example.com` does not match `https://API.Example.com/v1/users`, so traffic the operator already approved falls through to the LLM judge. That is a judge call on every such request, or a denial when the fallback is deny.

Deny rules have the same gap. It matters most when a broad allow rule is paired with a host-based deny carve-out, since a static allow returns before the judge runs.

## Fix

Lower-case the scheme and host of both the URL and the pattern before matching. Only the authority is folded, so paths and query strings keep their case. Userinfo ahead of `@` is left alone.

Doing this inside `staticURLMatches` covers prefix, exact and glob rules, and `MatchesStaticRules` in the eval runner picks it up as well.

## Tests

`TestStaticRuleHostCaseInsensitive` covers upper and mixed case hosts against prefix, exact and glob rules for both actions, including a pattern authored in upper case matched against a lower-case request. It also asserts that a path differing only in case still does not match, so the fold stays limited to the authority.

Four rows added to `TestStaticURLMatches` for the same behaviour at the matcher level.

Ran `go test ./internal/approval/` on Go 1.26.1 with the testcontainers Postgres setup. The new cases fail before the change and pass after it, and the rest of the package is unaffected.
