### PR TITLE
fix(audit): redact credential headers before persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The proxy listens on `localhost:8080`, the admin UI is at `localhost:8081` and y
 ## What CrabTrap Does NOT Do
 
 - **Not a WAF or inbound firewall** — CrabTrap is a forward proxy (outbound-only) for agent-originated traffic. It does not inspect inbound requests to your services.
-- **Does not redact sensitive data** — the proxy sees all request content in cleartext, including headers like Authorization and Cookie. This is by design; the trust boundary is the proxy itself.
+- **Does not redact request or response bodies** — the proxy sees request content in cleartext. Credential-bearing audit headers (including Authorization, Cookie, and API-key headers) are replaced with `[REDACTED]` before any audit sink receives them.
 - **Does not provide human-in-the-loop approval** — there is no approval queue, no Slack prompts, and no escalation path. Decisions are made automatically by static rules and the LLM judge.
 - **Does not filter API responses** — only outbound requests are evaluated. Responses from upstream APIs are streamed back to the agent unexamined.
 - **Does not inspect WebSocket frames** — only the WebSocket upgrade request is evaluated. Once upgraded, frames pass through uninspected.

--- a/internal/audit/redact.go
+++ b/internal/audit/redact.go
@@ -1,0 +1,47 @@
+package audit
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/brexhq/CrabTrap/pkg/types"
+)
+
+const redactedHeaderValue = "[REDACTED]"
+
+var sensitiveHeaders = map[string]struct{}{
+	"api-key":             {},
+	"authorization":       {},
+	"cookie":              {},
+	"private-token":       {},
+	"proxy-authorization": {},
+	"set-cookie":          {},
+	"x-amz-security-token": {},
+	"x-api-key":           {},
+	"x-auth-token":        {},
+	"x-goog-api-key":      {},
+}
+
+// RedactEntryHeaders returns a copy of entry with credential-bearing request
+// and response header values removed. The caller's header maps are not mutated.
+func RedactEntryHeaders(entry types.AuditEntry) types.AuditEntry {
+	entry.RequestHeaders = RedactHeaders(entry.RequestHeaders)
+	entry.ResponseHeaders = RedactHeaders(entry.ResponseHeaders)
+	return entry
+}
+
+// RedactHeaders clones headers and replaces sensitive values while preserving
+// header names so the audit trail still records that a credential was present.
+func RedactHeaders(headers http.Header) http.Header {
+	if headers == nil {
+		return nil
+	}
+
+	redacted := headers.Clone()
+	for name := range redacted {
+		if _, sensitive := sensitiveHeaders[strings.ToLower(name)]; sensitive {
+			redacted[name] = []string{redactedHeaderValue}
+		}
+	}
+	return redacted
+}

--- a/internal/audit/redact_test.go
+++ b/internal/audit/redact_test.go
@@ -1,0 +1,58 @@
+package audit
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/brexhq/CrabTrap/pkg/types"
+)
+
+func TestRedactEntryHeaders(t *testing.T) {
+	requestHeaders := http.Header{
+		"Api-Key":             []string{"api-secret"},
+		"authorization":       []string{"Bearer secret"},
+		"Cookie":              []string{"session=secret"},
+		"Private-Token":       []string{"private-secret"},
+		"Proxy-Authorization": []string{"Basic secret"},
+		"X-Amz-Security-Token": []string{"aws-secret"},
+		"X-Api-Key":           []string{"api-secret"},
+		"X-Auth-Token":        []string{"token-secret"},
+		"X-Goog-Api-Key":      []string{"google-secret"},
+		"Content-Type":        []string{"application/json"},
+	}
+	responseHeaders := http.Header{
+		"Set-Cookie": []string{"session=secret", "csrf=secret"},
+		"X-Trace-Id": []string{"trace-123"},
+	}
+	entry := types.AuditEntry{RequestHeaders: requestHeaders, ResponseHeaders: responseHeaders}
+
+	got := RedactEntryHeaders(entry)
+
+	for _, name := range []string{"Api-Key", "authorization", "Cookie", "Private-Token", "Proxy-Authorization", "X-Amz-Security-Token", "X-Api-Key", "X-Auth-Token", "X-Goog-Api-Key"} {
+		if values := got.RequestHeaders[name]; !reflect.DeepEqual(values, []string{redactedHeaderValue}) {
+			t.Errorf("request header %s = %v, want redacted", name, values)
+		}
+	}
+	if values := got.ResponseHeaders.Values("Set-Cookie"); !reflect.DeepEqual(values, []string{redactedHeaderValue}) {
+		t.Errorf("response Set-Cookie = %v, want redacted", values)
+	}
+	if values := got.RequestHeaders.Values("Content-Type"); !reflect.DeepEqual(values, []string{"application/json"}) {
+		t.Errorf("request Content-Type = %v, want unchanged", values)
+	}
+	if values := got.ResponseHeaders.Values("X-Trace-Id"); !reflect.DeepEqual(values, []string{"trace-123"}) {
+		t.Errorf("response X-Trace-Id = %v, want unchanged", values)
+	}
+	if values := requestHeaders["authorization"]; !reflect.DeepEqual(values, []string{"Bearer secret"}) {
+		t.Errorf("caller's Authorization header was mutated: %v", values)
+	}
+	if values := responseHeaders.Values("Set-Cookie"); !reflect.DeepEqual(values, []string{"session=secret", "csrf=secret"}) {
+		t.Errorf("caller's Set-Cookie header was mutated: %v", values)
+	}
+}
+
+func TestRedactHeadersPreservesNil(t *testing.T) {
+	if got := RedactHeaders(nil); got != nil {
+		t.Fatalf("RedactHeaders(nil) = %v, want nil", got)
+	}
+}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1848,6 +1848,7 @@ func applyDecision(e *types.AuditEntry, d types.ApprovalDecision, llmResponseID,
 
 // logEntry dispatches a fully-built audit entry to the DB reader, SSE, and audit file.
 func (h *Handler) logEntry(entry types.AuditEntry) {
+	entry = audit.RedactEntryHeaders(entry)
 	if h.auditReader != nil {
 		h.auditReader.Add(entry)
 	}
@@ -1859,7 +1860,7 @@ func (h *Handler) updateResponseAudit(requestID string, responseStatus int, resp
 		slog.Warn("streamed response audit update skipped because audit reader is not configured", "request_id", requestID)
 		return
 	}
-	if err := h.auditReader.UpdateResponse(requestID, responseStatus, responseHeaders, responseBody, errText, durationMs); err != nil {
+	if err := h.auditReader.UpdateResponse(requestID, responseStatus, audit.RedactHeaders(responseHeaders), responseBody, errText, durationMs); err != nil {
 		slog.Error("failed to update streamed response audit", "request_id", requestID, "error", err)
 	}
 }


### PR DESCRIPTION
## Summary

Redact credential-bearing request and response header values before audit entries reach any sink. This prevents cleartext credentials from being persisted to PostgreSQL or JSONL while preserving header names for audit evidence. Streamed-response database updates receive the same treatment.

## Changes

- add a case-insensitive denylist for Authorization, Cookie, Set-Cookie, proxy auth, and common API/token headers
- clone header maps before replacing values with `[REDACTED]`
- apply redaction before the shared DB/SSE/file dispatch and before streamed response updates
- document the audit-header behavior
- add unit coverage for sensitive, non-sensitive, multi-value, case-insensitive, immutability, and nil-header behavior

## Verification

Local execution was unavailable in the authoring environment because Go is not installed and Docker daemon access is restricted. The focused tests are included in `internal/audit/redact_test.go`; the repository CI should run lint, race-enabled Go tests with PostgreSQL, and the Docker build.

## Risk

The denylist is intentionally explicit: unknown proprietary credential headers still require adding their name. Request and response bodies remain unchanged.